### PR TITLE
[Merged by Bors] - refactor(Data/Nat/MaxPowDiv): prove `padicValNat = multiplicity` earlier

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4359,6 +4359,7 @@ public import Mathlib.Data.Nat.Nth
 public import Mathlib.Data.Nat.NthRoot.Defs
 public import Mathlib.Data.Nat.Order.Lemmas
 public import Mathlib.Data.Nat.PSub
+public import Mathlib.Data.Nat.PadicValNat
 public import Mathlib.Data.Nat.Pairing
 public import Mathlib.Data.Nat.Periodic
 public import Mathlib.Data.Nat.Prime.Basic

--- a/Mathlib/Data/Nat/MaxPowDiv.lean
+++ b/Mathlib/Data/Nat/MaxPowDiv.lean
@@ -70,9 +70,6 @@ theorem maxPowDvdDiv.go_spec {n p : ℕ} (hnp) :
   | case3 =>
     simp_all [Nat.dvd_iff_mod_eq_zero]
 
-theorem not_dvd_divMaxPow {p n : ℕ} (hp : 1 < p) (hn : n ≠ 0) : ¬p ∣ divMaxPow n p := by
-  simp [divMaxPow, maxPowDvdDiv, maxPowDvdDiv.go_spec, *]
-
 theorem maxPowDvdDiv_of_base_le_one {p : ℕ} (hp : p ≤ 1) (n : ℕ) : maxPowDvdDiv p n = (0, n) := by
   simp [maxPowDvdDiv, Nat.not_lt_of_ge hp]
 
@@ -95,6 +92,9 @@ theorem maxPowDvdDiv_zero_right (p : ℕ) : maxPowDvdDiv p 0 = (0, 0) := by simp
 
 @[simp]
 theorem divMaxPow_zero_left (p : ℕ) : divMaxPow 0 p = 0 := by simp [divMaxPow]
+
+theorem not_dvd_divMaxPow {p n : ℕ} (hp : 1 < p) (hn : n ≠ 0) : ¬p ∣ divMaxPow n p := by
+  simp [divMaxPow, maxPowDvdDiv, maxPowDvdDiv.go_spec, *]
 
 private theorem pow_dvd_iff_le_of_spec {p k n a b : ℕ} (hp : 1 < p) (hn : n ≠ 0)
     (hab : p ^ a * b = n) (hb : ¬p ∣ b) : p ^ k ∣ n ↔ k ≤ a := by

--- a/Mathlib/Data/Nat/MaxPowDiv.lean
+++ b/Mathlib/Data/Nat/MaxPowDiv.lean
@@ -9,6 +9,7 @@ public import Mathlib.Basic.Logic.Basic
 
 import Mathlib.Data.Nat.Notation
 public import Mathlib.Data.Nat.Notation
+public import Mathlib.RingTheory.Multiplicity
 
 /-!
 # The maximal power of one natural number dividing another
@@ -41,7 +42,7 @@ def maxPowDvdDiv (p n : ℕ) : ℕ × ℕ :=
   /-- Auxiliary definition for `Nat.maxPowDvdDiv`. -/
   go (p : ℕ) (hp : 1 < p ∧ n ≠ 0) :=
     if hmod : n % p = 0 then
-      let (e, q) := go (p * p) <| by simp [Nat.one_lt_mul_iff, hp, Nat.lt_trans Nat.one_pos]
+      let (e, q) := go (p * p) <| by simp [hp]
       if q % p = 0 then (2 * e + 1, q / p) else (2 * e, q)
     else
       (0, n)
@@ -75,6 +76,52 @@ theorem maxPowDvdDiv.go_spec {n p : ℕ} (hnp) :
     simp_all [Nat.dvd_iff_mod_eq_zero, Nat.two_mul, Nat.mul_pow, Nat.pow_add]
   | case3 =>
     simp_all [Nat.dvd_iff_mod_eq_zero]
+
+open maxPowDvdDiv in
+@[simp]
+theorem divMaxPow_mul_pow_padicValNat (p n : ℕ) : divMaxPow n p * p ^ padicValNat p n = n := by
+  unfold divMaxPow padicValNat
+  fun_cases maxPowDvdDiv with
+  | case1 h => exact go_spec h |>.1
+  | case2 h => simp
+
+theorem not_dvd_divMaxPow {p n : ℕ} (hp1 : p ≠ 1) (hn : n ≠ 0) : ¬p ∣ divMaxPow n p := by
+  by_cases hp0 : p = 0
+  · simpa [hp0, divMaxPow, maxPowDvdDiv]
+  have hp : 1 < p := Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨hp0, hp1⟩
+  simp [divMaxPow, maxPowDvdDiv, maxPowDvdDiv.go_spec, *]
+
+theorem padicValNat_def {p n : ℕ} : padicValNat p n = multiplicity p n := by
+  by_cases hn : n = 0
+  · simp [padicValNat, maxPowDvdDiv, hn]
+  by_cases hp : p = 1
+  · simp [padicValNat, maxPowDvdDiv, hp]
+  have key := not_dvd_divMaxPow hp hn
+
+
+  have key := divMaxPow_mul_pow_padicValNat p n
+  by_cases hn : n = 0
+  · simp [hn]
+    sorry
+  by_cases hp : p = 1
+  · simp [hp]
+    sorry
+  by_cases hp : p = 0
+  · rw [hp] at key
+    simp [hp]
+    sorry
+  have h : FiniteMultiplicity p n := finiteMultiplicity_iff.mpr ⟨hp, pos_of_ne_zero hn⟩
+  refine (h.multiplicity_eq_iff.mpr ⟨Dvd.intro_left (n.divMaxPow p)
+    (divMaxPow_mul_pow_padicValNat p n), ?_⟩).symm
+  have := divMaxPow_mul_pow_padicValNat p n
+  have key := not_dvd_divMaxPow hp hn
+  contrapose! key
+  by_cases hp : p = 0
+  · simp_all
+  intro h'
+
+
+  have := divMaxPow_mul_pow_padicValNat p n
 
 theorem maxPowDvdDiv_of_base_le_one {p : ℕ} (hp : p ≤ 1) (n : ℕ) : maxPowDvdDiv p n = (0, n) := by
   simp [maxPowDvdDiv, Nat.not_lt_of_ge hp]
@@ -123,13 +170,7 @@ theorem _root_.padicValNat_one_right (p : ℕ) : padicValNat p 1 = 0 := by simp 
 @[simp]
 theorem divMaxPow_one_left (p : ℕ) : divMaxPow 1 p = 1 := by simp [divMaxPow]
 
-open maxPowDvdDiv in
-@[simp]
-theorem divMaxPow_mul_pow_padicValNat (p n : ℕ) : divMaxPow n p * p ^ padicValNat p n = n := by
-  unfold divMaxPow padicValNat
-  fun_cases maxPowDvdDiv with
-  | case1 h => exact go_spec h |>.1
-  | case2 h => simp
+
 
 @[simp]
 theorem pow_padicValNat_mul_divMaxPow (p n : ℕ) : p ^ padicValNat p n * divMaxPow n p = n := by
@@ -150,9 +191,6 @@ theorem padicValNat_le_self {p : ℕ} (n : ℕ) : padicValNat p n ≤ n := by
   rcases eq_or_ne n 0 with rfl | hn
   · simp
   · exact Nat.le_of_lt <| padicValNat_lt_self hn
-
-theorem not_dvd_divMaxPow {p n : ℕ} (hp : 1 < p) (hn : n ≠ 0) : ¬p ∣ divMaxPow n p := by
-  simp [divMaxPow, maxPowDvdDiv, maxPowDvdDiv.go_spec, *]
 
 private theorem pow_dvd_iff_le_of_spec {p k n a b : ℕ} (hp : 1 < p) (hn : n ≠ 0)
     (hab : p ^ a * b = n) (hb : ¬p ∣ b) : p ^ k ∣ n ↔ k ≤ a := by

--- a/Mathlib/Data/Nat/MaxPowDiv.lean
+++ b/Mathlib/Data/Nat/MaxPowDiv.lean
@@ -110,7 +110,4 @@ private theorem pow_dvd_iff_le_of_spec {p k n a b : ℕ} (hp : 1 < p) (hn : n �
     refine iff_of_true (Nat.dvd_mul_right_of_dvd ?_ _) hle
     exact Nat.pow_dvd_pow p hle
 
-@[simp]
-theorem snd_maxPowDvdDiv (p n : ℕ) : (p.maxPowDvdDiv n).2 = n.divMaxPow p := rfl
-
 end Nat

--- a/Mathlib/Data/Nat/MaxPowDiv.lean
+++ b/Mathlib/Data/Nat/MaxPowDiv.lean
@@ -5,11 +5,8 @@ Authors: Matthew Robert Ballard, Yury Kudryashov
 -/
 module
 
-public import Mathlib.Basic.Logic.Basic
 
 import Mathlib.Data.Nat.Notation
-public import Mathlib.Data.Nat.Notation
-public import Mathlib.RingTheory.Multiplicity
 
 /-!
 # The maximal power of one natural number dividing another
@@ -42,7 +39,7 @@ def maxPowDvdDiv (p n : ℕ) : ℕ × ℕ :=
   /-- Auxiliary definition for `Nat.maxPowDvdDiv`. -/
   go (p : ℕ) (hp : 1 < p ∧ n ≠ 0) :=
     if hmod : n % p = 0 then
-      let (e, q) := go (p * p) <| by simp [hp]
+      let (e, q) := go (p * p) <| by simp [Nat.one_lt_mul_iff, hp, Nat.lt_trans Nat.one_pos]
       if q % p = 0 then (2 * e + 1, q / p) else (2 * e, q)
     else
       (0, n)
@@ -53,10 +50,6 @@ def maxPowDvdDiv (p n : ℕ) : ℕ × ℕ :=
     have hp₀ : 0 < p := Nat.lt_trans Nat.one_pos hp.1
     rw [Nat.mul_div_mul_left _ _ hp₀, Nat.mul_div_cancel_left _ hp₀]
     exact Nat.div_lt_self (by grind) hp.1
-
-/-- For `p ≠ 1`, the `p`-adic valuation of a natural `n ≠ 0` is the largest natural number `k` such
-that `p^k` divides `n`. If `n = 0` or `p = 1`, then `padicValNat p n` defaults to `0`. -/
-def _root_.padicValNat (p n : ℕ) : ℕ := (maxPowDvdDiv p n).fst
 
 /-- Divide `n` by the maximal power of `p` that divides `n`. -/
 def divMaxPow (n p : ℕ) : ℕ := (maxPowDvdDiv p n).snd
@@ -77,29 +70,8 @@ theorem maxPowDvdDiv.go_spec {n p : ℕ} (hnp) :
   | case3 =>
     simp_all [Nat.dvd_iff_mod_eq_zero]
 
-open maxPowDvdDiv in
-@[simp]
-theorem divMaxPow_mul_pow_padicValNat (p n : ℕ) : divMaxPow n p * p ^ padicValNat p n = n := by
-  unfold divMaxPow padicValNat
-  fun_cases maxPowDvdDiv with
-  | case1 h => exact go_spec h |>.1
-  | case2 h => simp
-
-theorem not_dvd_divMaxPow {p n : ℕ} (hp : p ≠ 1) (hn : n ≠ 0) : ¬p ∣ divMaxPow n p := by
-  cases lt_or_gt_of_ne hp <;> simp_all [divMaxPow, maxPowDvdDiv, maxPowDvdDiv.go_spec]
-
-theorem padicValNat_def {p n : ℕ} : padicValNat p n = multiplicity p n := by
-  by_cases hn : n = 0
-  · simp [padicValNat, maxPowDvdDiv, hn]
-  by_cases hp : p = 1
-  · simp [padicValNat, maxPowDvdDiv, hp]
-  refine .symm <| multiplicity_eq_of_dvd_of_not_dvd
-    (Dvd.intro_left (n.divMaxPow p) (divMaxPow_mul_pow_padicValNat p n)) ?_
-  by_cases hp0 : p = 0
-  · simp_all
-  nth_rw 2 [← divMaxPow_mul_pow_padicValNat p n]
-  rw [pow_add_one', mul_dvd_mul_iff_right (pow_ne_zero (padicValNat p n) hp0)]
-  exact not_dvd_divMaxPow hp hn
+theorem not_dvd_divMaxPow {p n : ℕ} (hp : 1 < p) (hn : n ≠ 0) : ¬p ∣ divMaxPow n p := by
+  simp [divMaxPow, maxPowDvdDiv, maxPowDvdDiv.go_spec, *]
 
 theorem maxPowDvdDiv_of_base_le_one {p : ℕ} (hp : p ≤ 1) (n : ℕ) : maxPowDvdDiv p n = (0, n) := by
   simp [maxPowDvdDiv, Nat.not_lt_of_ge hp]
@@ -109,17 +81,11 @@ theorem maxPowDvdDiv_zero_left (n : ℕ) : maxPowDvdDiv 0 n = (0, n) :=
   maxPowDvdDiv_of_base_le_one (Nat.zero_le _) _
 
 @[simp]
-theorem _root_.padicValNat_zero_left (n : ℕ) : padicValNat 0 n = 0 := by simp [padicValNat]
-
-@[simp]
 theorem divMaxPow_zero_right (n : ℕ) : divMaxPow n 0 = n := by simp [divMaxPow]
 
 @[simp]
 theorem maxPowDvdDiv_one_left (n : ℕ) : maxPowDvdDiv 1 n = (0, n) :=
   maxPowDvdDiv_of_base_le_one (Nat.le_refl _) _
-
-@[simp]
-theorem _root_.padicValNat_one_left (n : ℕ) : padicValNat 1 n = 0 := by simp [padicValNat]
 
 @[simp]
 theorem divMaxPow_one_right (n : ℕ) : divMaxPow n 1 = n := by simp [divMaxPow]
@@ -128,45 +94,7 @@ theorem divMaxPow_one_right (n : ℕ) : divMaxPow n 1 = n := by simp [divMaxPow]
 theorem maxPowDvdDiv_zero_right (p : ℕ) : maxPowDvdDiv p 0 = (0, 0) := by simp [maxPowDvdDiv]
 
 @[simp]
-theorem _root_.padicValNat_zero_right (p : ℕ) : padicValNat p 0 = 0 := by simp [padicValNat]
-
-@[simp]
 theorem divMaxPow_zero_left (p : ℕ) : divMaxPow 0 p = 0 := by simp [divMaxPow]
-
-theorem maxPowDvdDiv_of_not_dvd {p n : ℕ} (h : ¬p ∣ n) : maxPowDvdDiv p n = (0, n) := by
-  cases n with
-  | zero => simp at h
-  | succ n => simp [maxPowDvdDiv, Nat.dvd_iff_mod_eq_zero.not.mp h, maxPowDvdDiv.go]
-
-@[simp]
-theorem maxPowDvdDiv_one_right (p : ℕ) : maxPowDvdDiv p 1 = (0, 1) := by
-  rcases eq_or_ne p 1 with rfl | hp <;> simp [maxPowDvdDiv_of_not_dvd, *]
-
-@[simp]
-theorem _root_.padicValNat_one_right (p : ℕ) : padicValNat p 1 = 0 := by simp [padicValNat]
-
-@[simp]
-theorem divMaxPow_one_left (p : ℕ) : divMaxPow 1 p = 1 := by simp [divMaxPow]
-
-@[simp]
-theorem pow_padicValNat_mul_divMaxPow (p n : ℕ) : p ^ padicValNat p n * divMaxPow n p = n := by
-  rw [Nat.mul_comm, divMaxPow_mul_pow_padicValNat]
-
-theorem _root_.pow_padicValNat_dvd {p n : ℕ} : p ^ padicValNat p n ∣ n :=
-  ⟨divMaxPow n p, by simp⟩
-
-theorem padicValNat_lt_self {p n : ℕ} (hn : n ≠ 0) : padicValNat p n < n := by
-  match p with
-  | 0 | 1 => simp [Nat.pos_of_ne_zero hn]
-  | p + 2 =>
-    apply (p + 2 |>.pow_lt_pow_iff_right <| by lia).mp
-    apply Nat.lt_of_le_of_lt ?_ <| Nat.lt_pow_self <| by lia
-    exact le_of_dvd (Nat.pos_of_ne_zero hn) pow_padicValNat_dvd
-
-theorem padicValNat_le_self {p : ℕ} (n : ℕ) : padicValNat p n ≤ n := by
-  rcases eq_or_ne n 0 with rfl | hn
-  · simp
-  · exact Nat.le_of_lt <| padicValNat_lt_self hn
 
 private theorem pow_dvd_iff_le_of_spec {p k n a b : ℕ} (hp : 1 < p) (hn : n ≠ 0)
     (hab : p ^ a * b = n) (hb : ¬p ∣ b) : p ^ k ∣ n ↔ k ≤ a := by
@@ -182,114 +110,7 @@ private theorem pow_dvd_iff_le_of_spec {p k n a b : ℕ} (hp : 1 < p) (hn : n �
     refine iff_of_true (Nat.dvd_mul_right_of_dvd ?_ _) hle
     exact Nat.pow_dvd_pow p hle
 
-/-- If `p > 1`, `n > 0`, then the first component of `maxPowDvdDiv` is the maximal power of `p`
-that divides `n`. -/
-theorem pow_dvd_iff_le_padicValNat {p k n : ℕ} (hp : p ≠ 1) (hn : n ≠ 0) :
-    p ^ k ∣ n ↔ k ≤ padicValNat p n := by
-  obtain rfl | hp₁ : p = 0 ∨ 1 < p := by grind
-  · rcases k.eq_zero_or_pos with rfl | hk <;> simp [Nat.ne_of_gt, *]
-  · exact pow_dvd_iff_le_of_spec hp₁ hn (pow_padicValNat_mul_divMaxPow p n)
-      (not_dvd_divMaxPow hp hn)
-
-theorem maxPowDvdDiv_of_pow_mul_eq {p n k l : ℕ} (hn : n ≠ 0) (h : p ^ k * l = n)
-    (hl : ¬p ∣ l) : maxPowDvdDiv p n = (k, l) := by
-  obtain rfl | rfl | hp : p = 0 ∨ p = 1 ∨ 1 < p := by grind
-  · cases k.eq_zero_or_pos <;> simp_all
-  · simp_all
-  · have hk : k = (p.maxPowDvdDiv n).1 := by
-      · apply Nat.le_antisymm
-        · rw [← padicValNat, ← pow_dvd_iff_le_padicValNat (Nat.ne_of_gt hp) hn,
-            pow_dvd_iff_le_of_spec hp hn h hl]
-        · rw [← pow_dvd_iff_le_of_spec hp hn h hl, pow_dvd_iff_le_padicValNat (Nat.ne_of_gt hp) hn]
-          apply Nat.le_refl
-    rw [← pow_padicValNat_mul_divMaxPow p n, hk, padicValNat, Nat.mul_left_cancel_iff] at h
-    · exact Prod.ext hk.symm h.symm
-    · exact Nat.pow_pos <| Nat.zero_lt_of_lt hp
-
-@[simp]
-theorem maxPowDvdDiv_base_pow_mul {p n : ℕ} (hp : 1 < p) (hn : n ≠ 0) (k : ℕ) :
-    p.maxPowDvdDiv (p ^ k * n) = (padicValNat p n + k, divMaxPow n p) := by
-  apply maxPowDvdDiv_of_pow_mul_eq
-  · exact Nat.mul_ne_zero (Nat.ne_of_gt <| Nat.pow_pos <| Nat.zero_lt_of_lt hp) hn
-  · rw [Nat.pow_add, Nat.mul_assoc, Nat.mul_left_comm, pow_padicValNat_mul_divMaxPow]
-  · exact not_dvd_divMaxPow hp.ne' hn
-
-@[simp]
-theorem _root_.padicValNat_base_pow_mul {p n : ℕ} (hp : 1 < p) (hn : n ≠ 0) (k : ℕ) :
-    padicValNat p (p ^ k * n) = padicValNat p n + k := by
-  simp [padicValNat, *]
-
-@[simp]
-theorem divMaxPow_base_pow_mul {p : ℕ} (hp : p ≠ 0) (n k : ℕ) :
-    (p ^ k * n).divMaxPow p = n.divMaxPow p := by
-  obtain rfl | hp1 : p = 1 ∨ 1 < p := by grind
-  · simp
-  · rcases eq_or_ne n 0 with rfl | hn <;> simp [divMaxPow, *]
-
-@[simp]
-theorem maxPowDvdDiv_base_mul {p n : ℕ} (hp : 1 < p) (hn : n ≠ 0) :
-    p.maxPowDvdDiv (p * n) = (padicValNat p n + 1, divMaxPow n p) := by
-  simpa using maxPowDvdDiv_base_pow_mul hp hn 1
-
-@[simp]
-theorem _root_.padicValNat_base_mul {p n : ℕ} (hp : 1 < p) (hn : n ≠ 0) :
-    padicValNat p (p * n) = padicValNat p n + 1 := by
-  simp [padicValNat, *]
-
-@[simp]
-theorem divMaxPow_base_mul {p : ℕ} (hp : p ≠ 0) (n : ℕ) :
-    (p * n).divMaxPow p = n.divMaxPow p := by
-  simpa using divMaxPow_base_pow_mul hp n 1
-
-@[simp]
-theorem maxPowDvdDiv_base_pow {p : ℕ} (hp : 1 < p) (k : ℕ) : p.maxPowDvdDiv (p ^ k) = (k, 1) := by
-  simpa using maxPowDvdDiv_base_pow_mul hp Nat.one_ne_zero k
-
-@[simp]
-theorem _root_.padicValNat_base_pow {p : ℕ} (hp : 1 < p) (k : ℕ) : padicValNat p (p ^ k) = k := by
-  simp [padicValNat, hp]
-
-@[simp]
-theorem divMaxPow_base_pow {p : ℕ} (hp : p ≠ 0) (k : ℕ) : (p ^ k).divMaxPow p = 1 := by
-  simpa using divMaxPow_base_pow_mul hp 1 k
-
-@[simp]
-theorem maxPowDvdDiv_self {p : ℕ} (hp : 1 < p) : p.maxPowDvdDiv p = (1, 1) := by
-  simpa using maxPowDvdDiv_base_pow hp 1
-
-@[simp]
-theorem _root_.padicValNat_base {p : ℕ} (hp : 1 < p) : padicValNat p p = 1 := by
-  simpa using padicValNat_base_pow hp 1
-
-@[simp]
-theorem divMaxPow_self {p : ℕ} (hp : p ≠ 0) : p.divMaxPow p = 1 := by
-  simpa using divMaxPow_base_pow hp 1
-
-@[simp]
-theorem fst_maxPowDvdDiv (p n : ℕ) : (p.maxPowDvdDiv n).1 = padicValNat p n := rfl
-
 @[simp]
 theorem snd_maxPowDvdDiv (p n : ℕ) : (p.maxPowDvdDiv n).2 = n.divMaxPow p := rfl
-
-@[deprecated (since := "2026-03-15")]
-alias maxPowDiv := padicValNat
-
-@[deprecated (since := "2026-03-15")]
-alias maxPowDiv.base_mul_eq_succ := padicValNat_base_mul
-
-@[deprecated (since := "2026-03-15")]
-alias maxPowDiv.base_pow_mul := padicValNat_base_pow_mul
-
-@[deprecated (since := "2026-03-15")]
-alias ⟨_, maxPowDiv.le_of_dvd⟩ := pow_dvd_iff_le_padicValNat
-
-@[deprecated (since := "2026-03-15")]
-alias maxPowDiv.pow_dvd := pow_padicValNat_dvd
-
-@[deprecated (since := "2026-03-15")]
-alias maxPowDiv.zero := padicValNat_zero_right
-
-@[deprecated (since := "2026-03-15")]
-alias maxPowDiv.zero_base := padicValNat_zero_left
 
 end Nat

--- a/Mathlib/Data/Nat/MaxPowDiv.lean
+++ b/Mathlib/Data/Nat/MaxPowDiv.lean
@@ -85,43 +85,21 @@ theorem divMaxPow_mul_pow_padicValNat (p n : ℕ) : divMaxPow n p * p ^ padicVal
   | case1 h => exact go_spec h |>.1
   | case2 h => simp
 
-theorem not_dvd_divMaxPow {p n : ℕ} (hp1 : p ≠ 1) (hn : n ≠ 0) : ¬p ∣ divMaxPow n p := by
-  by_cases hp0 : p = 0
-  · simpa [hp0, divMaxPow, maxPowDvdDiv]
-  have hp : 1 < p := Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨hp0, hp1⟩
-  simp [divMaxPow, maxPowDvdDiv, maxPowDvdDiv.go_spec, *]
+theorem not_dvd_divMaxPow {p n : ℕ} (hp : p ≠ 1) (hn : n ≠ 0) : ¬p ∣ divMaxPow n p := by
+  cases lt_or_gt_of_ne hp <;> simp_all [divMaxPow, maxPowDvdDiv, maxPowDvdDiv.go_spec]
 
 theorem padicValNat_def {p n : ℕ} : padicValNat p n = multiplicity p n := by
   by_cases hn : n = 0
   · simp [padicValNat, maxPowDvdDiv, hn]
   by_cases hp : p = 1
   · simp [padicValNat, maxPowDvdDiv, hp]
-  have key := not_dvd_divMaxPow hp hn
-
-
-  have key := divMaxPow_mul_pow_padicValNat p n
-  by_cases hn : n = 0
-  · simp [hn]
-    sorry
-  by_cases hp : p = 1
-  · simp [hp]
-    sorry
-  by_cases hp : p = 0
-  · rw [hp] at key
-    simp [hp]
-    sorry
-  have h : FiniteMultiplicity p n := finiteMultiplicity_iff.mpr ⟨hp, pos_of_ne_zero hn⟩
-  refine (h.multiplicity_eq_iff.mpr ⟨Dvd.intro_left (n.divMaxPow p)
-    (divMaxPow_mul_pow_padicValNat p n), ?_⟩).symm
-  have := divMaxPow_mul_pow_padicValNat p n
-  have key := not_dvd_divMaxPow hp hn
-  contrapose! key
-  by_cases hp : p = 0
+  refine .symm <| multiplicity_eq_of_dvd_of_not_dvd
+    (Dvd.intro_left (n.divMaxPow p) (divMaxPow_mul_pow_padicValNat p n)) ?_
+  by_cases hp0 : p = 0
   · simp_all
-  intro h'
-
-
-  have := divMaxPow_mul_pow_padicValNat p n
+  nth_rw 2 [← divMaxPow_mul_pow_padicValNat p n]
+  rw [pow_add_one', mul_dvd_mul_iff_right (pow_ne_zero (padicValNat p n) hp0)]
+  exact not_dvd_divMaxPow hp hn
 
 theorem maxPowDvdDiv_of_base_le_one {p : ℕ} (hp : p ≤ 1) (n : ℕ) : maxPowDvdDiv p n = (0, n) := by
   simp [maxPowDvdDiv, Nat.not_lt_of_ge hp]
@@ -170,8 +148,6 @@ theorem _root_.padicValNat_one_right (p : ℕ) : padicValNat p 1 = 0 := by simp 
 @[simp]
 theorem divMaxPow_one_left (p : ℕ) : divMaxPow 1 p = 1 := by simp [divMaxPow]
 
-
-
 @[simp]
 theorem pow_padicValNat_mul_divMaxPow (p n : ℕ) : p ^ padicValNat p n * divMaxPow n p = n := by
   rw [Nat.mul_comm, divMaxPow_mul_pow_padicValNat]
@@ -213,7 +189,7 @@ theorem pow_dvd_iff_le_padicValNat {p k n : ℕ} (hp : p ≠ 1) (hn : n ≠ 0) :
   obtain rfl | hp₁ : p = 0 ∨ 1 < p := by grind
   · rcases k.eq_zero_or_pos with rfl | hk <;> simp [Nat.ne_of_gt, *]
   · exact pow_dvd_iff_le_of_spec hp₁ hn (pow_padicValNat_mul_divMaxPow p n)
-      (not_dvd_divMaxPow hp₁ hn)
+      (not_dvd_divMaxPow hp hn)
 
 theorem maxPowDvdDiv_of_pow_mul_eq {p n k l : ℕ} (hn : n ≠ 0) (h : p ^ k * l = n)
     (hl : ¬p ∣ l) : maxPowDvdDiv p n = (k, l) := by
@@ -224,7 +200,6 @@ theorem maxPowDvdDiv_of_pow_mul_eq {p n k l : ℕ} (hn : n ≠ 0) (h : p ^ k * l
       · apply Nat.le_antisymm
         · rw [← padicValNat, ← pow_dvd_iff_le_padicValNat (Nat.ne_of_gt hp) hn,
             pow_dvd_iff_le_of_spec hp hn h hl]
-          apply Nat.le_refl
         · rw [← pow_dvd_iff_le_of_spec hp hn h hl, pow_dvd_iff_le_padicValNat (Nat.ne_of_gt hp) hn]
           apply Nat.le_refl
     rw [← pow_padicValNat_mul_divMaxPow p n, hk, padicValNat, Nat.mul_left_cancel_iff] at h
@@ -237,7 +212,7 @@ theorem maxPowDvdDiv_base_pow_mul {p n : ℕ} (hp : 1 < p) (hn : n ≠ 0) (k : �
   apply maxPowDvdDiv_of_pow_mul_eq
   · exact Nat.mul_ne_zero (Nat.ne_of_gt <| Nat.pow_pos <| Nat.zero_lt_of_lt hp) hn
   · rw [Nat.pow_add, Nat.mul_assoc, Nat.mul_left_comm, pow_padicValNat_mul_divMaxPow]
-  · exact not_dvd_divMaxPow hp hn
+  · exact not_dvd_divMaxPow hp.ne' hn
 
 @[simp]
 theorem _root_.padicValNat_base_pow_mul {p n : ℕ} (hp : 1 < p) (hn : n ≠ 0) (k : ℕ) :

--- a/Mathlib/Data/Nat/PadicValNat.lean
+++ b/Mathlib/Data/Nat/PadicValNat.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2023 Matthew Robert Ballard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Matthew Robert Ballard, Yury Kudryashov
+-/
+module
+
+public import Mathlib.Data.Nat.MaxPowDiv
+public import Mathlib.RingTheory.Multiplicity
+
+/-!
+# The maximal power of one natural number dividing another
+
+Here we introduce `p.maxPowDvd n` which returns the maximal `k : ℕ` for
+which `p ^ k ∣ n` with the convention that `maxPowDvd 1 n = 0` for all `n`.
+
+We prove enough about `maxPowDvd` in this file to show equality with `Nat.padicValNat` in
+`padicValNat.padicValNat_eq_maxPowDvd`.
+
+The implementation of `maxPowDvd` improves on the speed of `padicValNat`.
+-/
+
+@[expose] public section
+
+namespace Nat
+
+/-- For `p ≠ 1`, the `p`-adic valuation of a natural `n ≠ 0` is the largest natural number `k` such
+that `p^k` divides `n`. If `n = 0` or `p = 1`, then `padicValNat p n` defaults to `0`. -/
+def _root_.padicValNat (p n : ℕ) : ℕ := (maxPowDvdDiv p n).fst
+
+open maxPowDvdDiv in
+@[simp]
+theorem divMaxPow_mul_pow_padicValNat (p n : ℕ) : divMaxPow n p * p ^ padicValNat p n = n := by
+  unfold divMaxPow padicValNat
+  fun_cases maxPowDvdDiv with
+  | case1 h => exact go_spec h |>.1
+  | case2 h => simp
+
+theorem padicValNat_def {p n : ℕ} : padicValNat p n = multiplicity p n := by
+  by_cases hn : n = 0
+  · simp [padicValNat, maxPowDvdDiv, hn]
+  by_cases hp : p = 1
+  · simp [padicValNat, maxPowDvdDiv, hp]
+  refine .symm <| multiplicity_eq_of_dvd_of_not_dvd
+    (Dvd.intro_left (n.divMaxPow p) (divMaxPow_mul_pow_padicValNat p n)) ?_
+  by_cases hp0 : p = 0
+  · simp_all
+  nth_rw 2 [← divMaxPow_mul_pow_padicValNat p n]
+  rw [pow_add_one', mul_dvd_mul_iff_right (pow_ne_zero (padicValNat p n) hp0)]
+  exact not_dvd_divMaxPow hp hn
+
+@[simp]
+theorem _root_.padicValNat_zero_left (n : ℕ) : padicValNat 0 n = 0 := by simp [padicValNat]
+
+@[simp]
+theorem _root_.padicValNat_one_left (n : ℕ) : padicValNat 1 n = 0 := by simp [padicValNat]
+
+@[simp]
+theorem _root_.padicValNat_zero_right (p : ℕ) : padicValNat p 0 = 0 := by simp [padicValNat]
+
+theorem maxPowDvdDiv_of_not_dvd {p n : ℕ} (h : ¬p ∣ n) : maxPowDvdDiv p n = (0, n) := by
+  cases n with
+  | zero => simp at h
+  | succ n => simp [maxPowDvdDiv, Nat.dvd_iff_mod_eq_zero.not.mp h, maxPowDvdDiv.go]
+
+@[simp]
+theorem maxPowDvdDiv_one_right (p : ℕ) : maxPowDvdDiv p 1 = (0, 1) := by
+  rcases eq_or_ne p 1 with rfl | hp <;> simp [maxPowDvdDiv_of_not_dvd, *]
+
+@[simp]
+theorem _root_.padicValNat_one_right (p : ℕ) : padicValNat p 1 = 0 := by simp [padicValNat]
+
+@[simp]
+theorem divMaxPow_one_left (p : ℕ) : divMaxPow 1 p = 1 := by simp [divMaxPow]
+
+@[simp]
+theorem pow_padicValNat_mul_divMaxPow (p n : ℕ) : p ^ padicValNat p n * divMaxPow n p = n := by
+  rw [Nat.mul_comm, divMaxPow_mul_pow_padicValNat]
+
+theorem _root_.pow_padicValNat_dvd {p n : ℕ} : p ^ padicValNat p n ∣ n :=
+  ⟨divMaxPow n p, by simp⟩
+
+theorem padicValNat_lt_self {p n : ℕ} (hn : n ≠ 0) : padicValNat p n < n := by
+  match p with
+  | 0 | 1 => simp [Nat.pos_of_ne_zero hn]
+  | p + 2 =>
+    apply (p + 2 |>.pow_lt_pow_iff_right <| by lia).mp
+    apply Nat.lt_of_le_of_lt ?_ <| Nat.lt_pow_self <| by lia
+    exact le_of_dvd (Nat.pos_of_ne_zero hn) pow_padicValNat_dvd
+
+theorem padicValNat_le_self {p : ℕ} (n : ℕ) : padicValNat p n ≤ n := by
+  rcases eq_or_ne n 0 with rfl | hn
+  · simp
+  · exact Nat.le_of_lt <| padicValNat_lt_self hn
+
+private theorem pow_dvd_iff_le_of_spec {p k n a b : ℕ} (hp : 1 < p) (hn : n ≠ 0)
+    (hab : p ^ a * b = n) (hb : ¬p ∣ b) : p ^ k ∣ n ↔ k ≤ a := by
+  subst hab
+  cases Nat.lt_or_ge a k with
+  | inl hlt =>
+    refine iff_of_false (fun hdvd ↦ ?_) (Nat.not_le_of_lt hlt)
+    obtain ⟨l, rfl⟩ := Nat.exists_eq_add_of_lt hlt
+    rw [Nat.add_assoc, Nat.pow_add,
+      Nat.mul_dvd_mul_iff_left (Nat.pow_pos (Nat.zero_lt_of_lt hp))] at hdvd
+    exact hb <| Nat.dvd_of_pow_dvd (Nat.le_add_left 1 l) hdvd
+  | inr hle =>
+    refine iff_of_true (Nat.dvd_mul_right_of_dvd ?_ _) hle
+    exact Nat.pow_dvd_pow p hle
+
+/-- If `p > 1`, `n > 0`, then the first component of `maxPowDvdDiv` is the maximal power of `p`
+that divides `n`. -/
+theorem pow_dvd_iff_le_padicValNat {p k n : ℕ} (hp : p ≠ 1) (hn : n ≠ 0) :
+    p ^ k ∣ n ↔ k ≤ padicValNat p n := by
+  obtain rfl | hp₁ : p = 0 ∨ 1 < p := by grind
+  · rcases k.eq_zero_or_pos with rfl | hk <;> simp [Nat.ne_of_gt, *]
+  · exact pow_dvd_iff_le_of_spec hp₁ hn (pow_padicValNat_mul_divMaxPow p n)
+      (not_dvd_divMaxPow hp₁ hn)
+
+theorem maxPowDvdDiv_of_pow_mul_eq {p n k l : ℕ} (hn : n ≠ 0) (h : p ^ k * l = n)
+    (hl : ¬p ∣ l) : maxPowDvdDiv p n = (k, l) := by
+  obtain rfl | rfl | hp : p = 0 ∨ p = 1 ∨ 1 < p := by grind
+  · cases k.eq_zero_or_pos <;> simp_all
+  · simp_all
+  · have hk : k = (p.maxPowDvdDiv n).1 := by
+      · apply Nat.le_antisymm
+        · rw [← padicValNat, ← pow_dvd_iff_le_padicValNat (Nat.ne_of_gt hp) hn,
+            pow_dvd_iff_le_of_spec hp hn h hl]
+        · rw [← pow_dvd_iff_le_of_spec hp hn h hl, pow_dvd_iff_le_padicValNat (Nat.ne_of_gt hp) hn]
+          apply Nat.le_refl
+    rw [← pow_padicValNat_mul_divMaxPow p n, hk, padicValNat, Nat.mul_left_cancel_iff] at h
+    · exact Prod.ext hk.symm h.symm
+    · exact Nat.pow_pos <| Nat.zero_lt_of_lt hp
+
+@[simp]
+theorem maxPowDvdDiv_base_pow_mul {p n : ℕ} (hp : 1 < p) (hn : n ≠ 0) (k : ℕ) :
+    p.maxPowDvdDiv (p ^ k * n) = (padicValNat p n + k, divMaxPow n p) := by
+  apply maxPowDvdDiv_of_pow_mul_eq
+  · exact Nat.mul_ne_zero (Nat.ne_of_gt <| Nat.pow_pos <| Nat.zero_lt_of_lt hp) hn
+  · rw [Nat.pow_add, Nat.mul_assoc, Nat.mul_left_comm, pow_padicValNat_mul_divMaxPow]
+  · exact not_dvd_divMaxPow hp hn
+
+@[simp]
+theorem _root_.padicValNat_base_pow_mul {p n : ℕ} (hp : 1 < p) (hn : n ≠ 0) (k : ℕ) :
+    padicValNat p (p ^ k * n) = padicValNat p n + k := by
+  simp [padicValNat, *]
+
+@[simp]
+theorem divMaxPow_base_pow_mul {p : ℕ} (hp : p ≠ 0) (n k : ℕ) :
+    (p ^ k * n).divMaxPow p = n.divMaxPow p := by
+  obtain rfl | hp1 : p = 1 ∨ 1 < p := by grind
+  · simp
+  · rcases eq_or_ne n 0 with rfl | hn <;> simp [divMaxPow, *]
+
+@[simp]
+theorem maxPowDvdDiv_base_mul {p n : ℕ} (hp : 1 < p) (hn : n ≠ 0) :
+    p.maxPowDvdDiv (p * n) = (padicValNat p n + 1, divMaxPow n p) := by
+  simpa using maxPowDvdDiv_base_pow_mul hp hn 1
+
+@[simp]
+theorem _root_.padicValNat_base_mul {p n : ℕ} (hp : 1 < p) (hn : n ≠ 0) :
+    padicValNat p (p * n) = padicValNat p n + 1 := by
+  simp [padicValNat, *]
+
+@[simp]
+theorem divMaxPow_base_mul {p : ℕ} (hp : p ≠ 0) (n : ℕ) :
+    (p * n).divMaxPow p = n.divMaxPow p := by
+  simpa using divMaxPow_base_pow_mul hp n 1
+
+@[simp]
+theorem maxPowDvdDiv_base_pow {p : ℕ} (hp : 1 < p) (k : ℕ) : p.maxPowDvdDiv (p ^ k) = (k, 1) := by
+  simpa using maxPowDvdDiv_base_pow_mul hp Nat.one_ne_zero k
+
+@[simp]
+theorem _root_.padicValNat_base_pow {p : ℕ} (hp : 1 < p) (k : ℕ) : padicValNat p (p ^ k) = k := by
+  simp [padicValNat, hp]
+
+@[simp]
+theorem divMaxPow_base_pow {p : ℕ} (hp : p ≠ 0) (k : ℕ) : (p ^ k).divMaxPow p = 1 := by
+  simpa using divMaxPow_base_pow_mul hp 1 k
+
+@[simp]
+theorem maxPowDvdDiv_self {p : ℕ} (hp : 1 < p) : p.maxPowDvdDiv p = (1, 1) := by
+  simpa using maxPowDvdDiv_base_pow hp 1
+
+@[simp]
+theorem _root_.padicValNat_base {p : ℕ} (hp : 1 < p) : padicValNat p p = 1 := by
+  simpa using padicValNat_base_pow hp 1
+
+@[simp]
+theorem divMaxPow_self {p : ℕ} (hp : p ≠ 0) : p.divMaxPow p = 1 := by
+  simpa using divMaxPow_base_pow hp 1
+
+@[simp]
+theorem fst_maxPowDvdDiv (p n : ℕ) : (p.maxPowDvdDiv n).1 = padicValNat p n := rfl
+
+@[deprecated (since := "2026-03-15")]
+alias maxPowDiv := padicValNat
+
+@[deprecated (since := "2026-03-15")]
+alias maxPowDiv.base_mul_eq_succ := padicValNat_base_mul
+
+@[deprecated (since := "2026-03-15")]
+alias maxPowDiv.base_pow_mul := padicValNat_base_pow_mul
+
+@[deprecated (since := "2026-03-15")]
+alias ⟨_, maxPowDiv.le_of_dvd⟩ := pow_dvd_iff_le_padicValNat
+
+@[deprecated (since := "2026-03-15")]
+alias maxPowDiv.pow_dvd := pow_padicValNat_dvd
+
+@[deprecated (since := "2026-03-15")]
+alias maxPowDiv.zero := padicValNat_zero_right
+
+@[deprecated (since := "2026-03-15")]
+alias maxPowDiv.zero_base := padicValNat_zero_left
+
+end Nat

--- a/Mathlib/Data/Nat/PadicValNat.lean
+++ b/Mathlib/Data/Nat/PadicValNat.lean
@@ -9,15 +9,7 @@ public import Mathlib.Data.Nat.MaxPowDiv
 public import Mathlib.RingTheory.Multiplicity
 
 /-!
-# The maximal power of one natural number dividing another
-
-Here we introduce `p.maxPowDvd n` which returns the maximal `k : ℕ` for
-which `p ^ k ∣ n` with the convention that `maxPowDvd 1 n = 0` for all `n`.
-
-We prove enough about `maxPowDvd` in this file to show equality with `Nat.padicValNat` in
-`padicValNat.padicValNat_eq_maxPowDvd`.
-
-The implementation of `maxPowDvd` improves on the speed of `padicValNat`.
+# The p-adic valuation on natural numbers
 -/
 
 @[expose] public section

--- a/Mathlib/Data/Nat/PadicValNat.lean
+++ b/Mathlib/Data/Nat/PadicValNat.lean
@@ -47,7 +47,7 @@ theorem padicValNat_def {p n : ℕ} : padicValNat p n = multiplicity p n := by
   · simp_all
   nth_rw 2 [← divMaxPow_mul_pow_padicValNat p n]
   rw [pow_add_one', mul_dvd_mul_iff_right (pow_ne_zero (padicValNat p n) hp0)]
-  exact not_dvd_divMaxPow hp hn
+  exact not_dvd_divMaxPow (Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨hp0, hp⟩) hn
 
 @[simp]
 theorem _root_.padicValNat_zero_left (n : ℕ) : padicValNat 0 n = 0 := by simp [padicValNat]
@@ -192,6 +192,9 @@ theorem divMaxPow_self {p : ℕ} (hp : p ≠ 0) : p.divMaxPow p = 1 := by
 
 @[simp]
 theorem fst_maxPowDvdDiv (p n : ℕ) : (p.maxPowDvdDiv n).1 = padicValNat p n := rfl
+
+@[simp]
+theorem snd_maxPowDvdDiv (p n : ℕ) : (p.maxPowDvdDiv n).2 = n.divMaxPow p := rfl
 
 @[deprecated (since := "2026-03-15")]
 alias maxPowDiv := padicValNat

--- a/Mathlib/NumberTheory/Padics/PadicVal/Defs.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal/Defs.lean
@@ -5,7 +5,7 @@ Authors: Robert Y. Lewis, Matthew Robert Ballard
 -/
 module
 
-public import Mathlib.Data.Nat.MaxPowDiv
+public import Mathlib.Data.Nat.PadicValNat
 public import Mathlib.RingTheory.Multiplicity
 public import Mathlib.Data.Nat.Factors
 

--- a/Mathlib/NumberTheory/Padics/PadicVal/Defs.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal/Defs.lean
@@ -46,14 +46,6 @@ theorem Nat.toNat_emultiplicity (p n : ℕ) : (emultiplicity p n).toNat = padicV
     · simp
     · simp [← padicValNat_eq_emultiplicity_of_ne_one, *]
 
-theorem padicValNat_def {n : ℕ} : padicValNat p n = multiplicity p n := by
-  by_cases hn : n = 0
-  · simp [hn]
-  by_cases hp : p = 1
-  · simp [hp]
-  exact (multiplicity_eq_of_emultiplicity_eq_some
-    (padicValNat_eq_emultiplicity_of_ne_one hp hn).symm).symm
-
 @[deprecated (since := "2026-09-08")] alias padicValNat_def' := padicValNat_def
 
 /-- A simplification of `padicValNat` when one input is prime, by analogy with


### PR DESCRIPTION
This PR proves `padicValNat = multiplicity` to ease the deprecation of `padicValNat`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
