### PR TITLE
feat(Data/SetLike): lattice membership typeclasses for `Min` and `Max`

### DIFF
--- a/Mathlib/Data/SetLike/Lattice.lean
+++ b/Mathlib/Data/SetLike/Lattice.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 Artie Khovanov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Artie Khovanov
+-/
+module
+
+public import Mathlib.Data.SetLike.Basic
+public import Mathlib.Data.Set.Insert
+public import Mathlib.Order.CompleteLattice.Defs
+
+/-!
+# Lattice operations agreeing with set operations
+
+This file defines several typeclasses for lattice operations that agree with the
+set operation described by a `Membership` instance.
+
+## Main definitions
+
+* `IsMemInf` : infinimum agrees with intersection
+* `IsMemSup` : supremum agrees with union
+
+-/
+
+@[expose] public section
+
+section defs
+
+variable (A : Type*) {B : Type*} [Membership B A]
+
+/-- A class to indicate that the infimum on a type corresponds to set intersection. -/
+class IsMemInf [Min A] where
+  /-- The infimum corresponds to set intersection. -/
+  protected mem_inf {S T : A} {x : B} : x ∈ S ⊓ T ↔ x ∈ S ∧ x ∈ T := by rfl
+
+@[simp] alias SetLike.mem_inf := IsMemInf.mem_inf
+
+/-- A class to indicate that the supremum on a type corresponds to set union. -/
+class IsMemSup [Max A] where
+  /-- The supremum corresponds to set union. -/
+  protected mem_sup {S T : A} {x : B} : x ∈ S ⊔ T ↔ x ∈ S ∨ x ∈ T := by rfl
+
+@[simp] alias SetLike.mem_sup := IsMemSup.mem_sup
+
+end defs
+
+section default
+
+variable (A : Type*) {B : Type*}
+
+@[reducible] def SemilatticeInf.ofSetLike [SetLike A B] [Min A] [IsMemInf A] :
+    SemilatticeInf A where
+  __ := PartialOrder.ofSetLike A B
+  inf := (· ⊓ ·)
+  inf_le_left := by simp [LE.le]; grind
+  inf_le_right := by simp [LE.le]
+  le_inf := by simp [LE.le]; grind
+
+@[reducible] def SemilatticeSup.ofSetLike [SetLike A B] [Max A] [IsMemSup A] :
+    SemilatticeSup A where
+  __ := PartialOrder.ofSetLike A B
+  sup := (· ⊔ ·)
+  le_sup_left := by simp [LE.le]; grind
+  le_sup_right := by simp [LE.le]; grind
+  sup_le := by simp [LE.le]; grind
+
+end default


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
