### PR TITLE
refactor(Algebra): correct the definition of non-abelian torsion-free groups

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Multiset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Multiset/Basic.lean
@@ -232,7 +232,7 @@ theorem sum_map_tsub [AddCommMonoid M] [PartialOrder M] [ExistsAddOfLE M]
 end OrderedSub
 
 instance {M : Type*} : IsAddTorsionFree (Multiset M) :=
-  ⟨fun n hn x y h ↦ open scoped Classical in Multiset.ext' fun _ ↦
-    (Nat.mul_right_inj hn).mp <| by simp only [← Multiset.count_nsmul, h]⟩
+  .of_nsmul_right_injective fun n hn x y h ↦ open scoped Classical in Multiset.ext' fun _ ↦
+    (Nat.mul_right_inj hn).mp <| by simp only [← Multiset.count_nsmul, h]
 
 end Multiset

--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -507,8 +507,9 @@ then so is the domain. -/
 then so is the domain. -/]
 theorem Function.Injective.isMulTorsionFree [Monoid M] [Monoid N] [IsMulTorsionFree N]
     (f : M →* N) (hf : Function.Injective f) : IsMulTorsionFree M where
-  pow_left_injective n hn x y hxy := hf <| IsMulTorsionFree.pow_left_injective hn <| by
-    simpa using congrArg f hxy
+  eq_of_pow_eq_pow_of_commute _n hn _x _y hxy hxyn :=
+    hf <| eq_of_pow_eq_pow_of_commute hn (by simpa using congrArg f hxy) <| by
+      simpa using congrArg f hxyn
 
 -- completely uninteresting lemmas about coercion to function, that all homs need
 section Coes

--- a/Mathlib/Algebra/Group/Int/Defs.lean
+++ b/Mathlib/Algebra/Group/Int/Defs.lean
@@ -55,8 +55,8 @@ instance instAddCommGroup : AddCommGroup ℤ where
 -- typeclass search, but it is better practice to not rely on algebraic order theory to prove
 -- purely algebraic results on concrete types. Eg the results can be made available earlier.
 
-instance instIsAddTorsionFree : IsAddTorsionFree ℤ where
-  nsmul_right_injective _n hn _x _y := Int.eq_of_mul_eq_mul_left (by lia)
+instance instIsAddTorsionFree : IsAddTorsionFree ℤ :=
+  .of_nsmul_right_injective fun _n hn _x _y ↦ Int.eq_of_mul_eq_mul_left (by lia)
 
 /-!
 ### Extra instances to short-circuit type class resolution

--- a/Mathlib/Algebra/Group/Monoid.lean
+++ b/Mathlib/Algebra/Group/Monoid.lean
@@ -508,18 +508,51 @@ This constructor is primarily intended to be used within proofs since it creates
 equalities. -/
 noncomputable abbrev IsUnital.toMonoid {A : Type*} [Semigroup A] [IsUnital A] : Monoid A where
 
-/-- An additive monoid is torsion-free if scalar multiplication by every non-zero element `n : ℕ` is
-injective. -/
+/-- An additive monoid is torsion-free if `n • a = n • b` implies `a = b` for all non-zero `n : ℕ`
+and all `a b : M` which commute.
+
+In an additive commutative monoid, this is equivalent to scalar multiplication by every non-zero
+`n : ℕ` being injective, see `isAddTorsionFree_iff_nsmul_right_injective`.
+In an additive group, this is equivalent to having no non-zero element of finite order, see
+`isAddTorsionFree_iff_not_isOfFinAddOrder`.
+
+It is not clear what the correct definition is for non-commutative additive monoids. -/
 @[mk_iff]
 class IsAddTorsionFree (M : Type*) [AddMonoid M] where
-  protected nsmul_right_injective ⦃n : ℕ⦄ (hn : n ≠ 0) : Injective fun a : M ↦ n • a
+  eq_of_nsmul_eq_nsmul_of_addCommute ⦃n : ℕ⦄ (hn : n ≠ 0) ⦃a b : M⦄ (hab : a + b = b + a)
+    (habn : n • a = n • b) : a = b
 
-/-- A monoid is torsion-free if power by every non-zero element `n : ℕ` is injective. -/
+/-- A monoid is torsion-free if `a ^ n = b ^ n` implies `a = b` for all non-zero `n : ℕ` and all
+`a b : M` which commute.
+
+In a commutative monoid, this is equivalent to power by every non-zero `n : ℕ` being injective,
+see `isMulTorsionFree_iff_pow_left_injective`.
+In a group, this is equivalent to having no non-trivial element of finite order, see
+`isMulTorsionFree_iff_not_isOfFinOrder`.
+
+It is not clear what the correct definition is for non-commutative monoids. -/
 @[to_additive, mk_iff]
 class IsMulTorsionFree (M : Type*) [Monoid M] where
-  protected pow_left_injective ⦃n : ℕ⦄ (hn : n ≠ 0) : Injective fun a : M ↦ a ^ n
+  -- `Commute` is not available yet, so we unfold it.
+  eq_of_pow_eq_pow_of_commute ⦃n : ℕ⦄ (hn : n ≠ 0) ⦃a b : M⦄ (hab : a * b = b * a)
+    (habn : a ^ n = b ^ n) : a = b
+
+export IsAddTorsionFree (eq_of_nsmul_eq_nsmul_of_addCommute)
+export IsMulTorsionFree (eq_of_pow_eq_pow_of_commute)
 
 attribute [to_additive existing] isMulTorsionFree_iff
+
+/-- A monoid in which power by every non-zero `n : ℕ` is injective is torsion-free.
+
+The converse holds in commutative monoids, see `pow_left_injective`. -/
+@[to_additive IsAddTorsionFree.of_nsmul_right_injective
+/-- An additive monoid in which scalar multiplication by every non-zero `n : ℕ` is injective is
+torsion-free.
+
+The converse holds in additive commutative monoids, see `nsmul_right_injective`. -/]
+lemma IsMulTorsionFree.of_pow_left_injective {M : Type*} [Monoid M]
+    (h : ∀ ⦃n : ℕ⦄, n ≠ 0 → Injective fun a : M ↦ a ^ n) : IsMulTorsionFree M where
+  eq_of_pow_eq_pow_of_commute _n hn _a _b _ habn := h hn habn
 
 /-- An additive commutative monoid is an additive monoid with commutative `(+)`. -/
 class AddCommMonoid (M : Type*) extends AddMonoid M, AddCommSemigroup M

--- a/Mathlib/Algebra/Group/Nat/Defs.lean
+++ b/Mathlib/Algebra/Group/Nat/Defs.lean
@@ -54,11 +54,11 @@ instance instCommMonoid : CommMonoid ℕ where
 -- typeclass search, but it is better practice to not rely on algebraic order theory to prove
 -- purely algebraic results on concrete types. Eg the results can be made available earlier.
 
-instance instIsMulTorsionFree : IsMulTorsionFree ℕ where
-  pow_left_injective _ h _ _ := (Nat.pow_left_inj h).mp
+instance instIsMulTorsionFree : IsMulTorsionFree ℕ :=
+  .of_pow_left_injective fun _ h _ _ ↦ (Nat.pow_left_inj h).mp
 
-instance instIsAddTorsionFree : IsAddTorsionFree ℕ where
-  nsmul_right_injective _n hn _x _y hxy := Nat.mul_left_cancel (Nat.pos_of_ne_zero hn) hxy
+instance instIsAddTorsionFree : IsAddTorsionFree ℕ :=
+  .of_nsmul_right_injective fun _n hn _x _y hxy ↦ Nat.mul_left_cancel (Nat.pos_of_ne_zero hn) hxy
 
 /-!
 ### Extra instances to short-circuit type class resolution

--- a/Mathlib/Algebra/Group/Opposite.lean
+++ b/Mathlib/Algebra/Group/Opposite.lean
@@ -301,7 +301,10 @@ instance instCommGroup [CommGroup α] : CommGroup αᵃᵒᵖ :=
     (fun _ _ => rfl) fun _ _ => rfl
 
 @[to_additive]
-instance instMulTorsionFree [Monoid α] [IsMulTorsionFree α] : IsMulTorsionFree αᵐᵒᵖ :=
-  ⟨fun _ h ↦ op_injective.comp <| (pow_left_injective h).comp <| unop_injective⟩
+instance instMulTorsionFree [Monoid α] [IsMulTorsionFree α] : IsMulTorsionFree αᵐᵒᵖ where
+  eq_of_pow_eq_pow_of_commute _n hn _a _b hab habn := MulOpposite.unop_injective <|
+    eq_of_pow_eq_pow_of_commute hn
+      (by simpa using congrArg MulOpposite.unop hab.symm)
+      (by simpa using congrArg MulOpposite.unop habn)
 
 end AddOpposite

--- a/Mathlib/Algebra/Group/Pi/Torsion.lean
+++ b/Mathlib/Algebra/Group/Pi/Torsion.lean
@@ -25,6 +25,7 @@ namespace Pi
 @[to_additive]
 instance instIsMulTorsionFree [∀ i, Monoid (M i)] [∀ i, IsMulTorsionFree (M i)] :
     IsMulTorsionFree (∀ i, M i) where
-  pow_left_injective n hn a b hab := by ext i; exact pow_left_injective hn <| congr_fun hab i
+  eq_of_pow_eq_pow_of_commute _n hn _a _b hab habn := funext fun i ↦
+    eq_of_pow_eq_pow_of_commute hn (congr_fun hab i) (congr_fun habn i)
 
 end Pi

--- a/Mathlib/Algebra/Group/Prod.lean
+++ b/Mathlib/Algebra/Group/Prod.lean
@@ -106,8 +106,9 @@ instance instMonoid [Monoid M] [Monoid N] : Monoid (M × N) :=
 @[to_additive]
 instance instIsMulTorsionFree [Monoid M] [Monoid N] [IsMulTorsionFree M] [IsMulTorsionFree N] :
     IsMulTorsionFree (M × N) where
-  pow_left_injective n hn a b hab := by
-    ext <;> apply pow_left_injective hn; exacts [congr(($hab).1), congr(($hab).2)]
+  eq_of_pow_eq_pow_of_commute _n hn _a _b hab habn := Prod.ext
+    (eq_of_pow_eq_pow_of_commute hn congr(($hab).1) congr(($habn).1))
+    (eq_of_pow_eq_pow_of_commute hn congr(($hab).2) congr(($habn).2))
 
 @[to_additive Prod.subNegMonoid]
 instance [DivInvMonoid G] [DivInvMonoid H] : DivInvMonoid (G × H) where

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -215,11 +215,8 @@ theorem pi_eq_bot_iff (H : ∀ i, Subgroup (f i)) : pi Set.univ H = ⊥ ↔ ∀ 
 end Pi
 
 @[to_additive]
-instance instIsMulTorsionFree [IsMulTorsionFree G] : IsMulTorsionFree H where
-  pow_left_injective n hn a b := by
-    have := pow_left_injective hn (M := G) (a₁ := a) (a₂ := b)
-    dsimp at *
-    norm_cast at this
+instance instIsMulTorsionFree [IsMulTorsionFree G] : IsMulTorsionFree H :=
+  Subtype.val_injective.isMulTorsionFree H.subtype
 
 end Subgroup
 

--- a/Mathlib/Algebra/Group/Torsion.lean
+++ b/Mathlib/Algebra/Group/Torsion.lean
@@ -6,6 +6,7 @@ Authors: Yaël Dillies, Patrick Luo
 module
 
 public import Mathlib.Algebra.Group.Basic
+public import Mathlib.Algebra.Group.Commute.Basic
 public import Mathlib.Algebra.Group.SelfInv
 public import Mathlib.Tactic.MkIffOfInductiveProp
 
@@ -13,7 +14,15 @@ public import Mathlib.Tactic.MkIffOfInductiveProp
 # Torsion-free monoids and groups
 
 This file proves lemmas about torsion-free monoids.
-A monoid `M` is *torsion-free* if `n • · : M → M` is injective for all non-zero natural numbers `n`.
+A monoid `M` is *torsion-free* if `a ^ n = b ^ n` implies `a = b` for all non-zero natural numbers
+`n` and all commuting `a b : M`.
+
+## Main statements
+
+* `isMulTorsionFree_iff_pow_left_injective`: A commutative monoid is torsion-free iff
+  `· ^ n : M → M` is injective for all non-zero natural numbers `n`.
+* `isMulTorsionFree_iff_eq_one_of_pow_eq_one`: A group is torsion-free iff it has no non-trivial
+  element `a` such that `a ^ n = 1` for some non-zero natural number `n`.
 -/
 
 public section
@@ -25,24 +34,22 @@ variable {M G : Type*}
 section Monoid
 variable [Monoid M]
 
-instance [AddCommMonoid M] [IsAddTorsionFree M] : Lean.Grind.NoNatZeroDivisors M where
-  no_nat_zero_divisors _ _ _ hk habk := IsAddTorsionFree.nsmul_right_injective hk habk
-
-@[to_additive] instance Subsingleton.to_isMulTorsionFree [Subsingleton M] : IsMulTorsionFree M where
-  pow_left_injective _ _ := injective_of_subsingleton _
+@[to_additive] instance Subsingleton.to_isMulTorsionFree [Subsingleton M] : IsMulTorsionFree M :=
+  .of_pow_left_injective fun _ _ ↦ injective_of_subsingleton _
 
 variable [IsMulTorsionFree M] {n : ℕ} {a b : M}
 
-@[to_additive nsmul_right_injective]
-lemma pow_left_injective (hn : n ≠ 0) : Injective fun a : M ↦ a ^ n :=
-  IsMulTorsionFree.pow_left_injective hn
+@[to_additive]
+lemma Commute.eq_of_pow_eq_pow (hab : Commute a b) (hn : n ≠ 0) (habn : a ^ n = b ^ n) : a = b :=
+  eq_of_pow_eq_pow_of_commute hn hab habn
 
-@[to_additive nsmul_right_inj]
-lemma pow_left_inj (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b := (pow_left_injective hn).eq_iff
+@[to_additive AddCommute.nsmul_right_inj]
+lemma Commute.pow_left_inj (hab : Commute a b) (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b :=
+  ⟨hab.eq_of_pow_eq_pow hn, congrArg (· ^ n)⟩
 
 @[to_additive nsmul_eq_zero_iff_right]
 lemma pow_eq_one_iff_left (hn : n ≠ 0) : a ^ n = 1 ↔ a = 1 := by
-  rw [← pow_left_inj (a := a) hn, one_pow]
+  rw [← (Commute.one_right a).pow_left_inj hn, one_pow]
 
 -- We want to use `IsAddTorsion.nsmul_eq_zero_iff` earlier than `smul_eq_zero`.
 @[to_additive (attr := simp high)]
@@ -58,27 +65,69 @@ lemma sq_eq_one : a ^ 2 = 1 ↔ a = 1 := pow_eq_one_iff_left (by lia)
 
 end Monoid
 
+section CommMonoid
+variable [CommMonoid M]
+
+/-- A commutative monoid is torsion-free if and only if power by every non-zero `n : ℕ` is
+injective. -/
+@[to_additive isAddTorsionFree_iff_nsmul_right_injective
+/-- An additive commutative monoid is torsion-free if and only if scalar multiplication by every
+non-zero `n : ℕ` is injective. -/]
+lemma isMulTorsionFree_iff_pow_left_injective :
+    IsMulTorsionFree M ↔ ∀ ⦃n : ℕ⦄, n ≠ 0 → Injective fun a : M ↦ a ^ n where
+  mp _ _ hn _ _ := (Commute.all _ _).eq_of_pow_eq_pow hn
+  mpr := .of_pow_left_injective
+
+variable [IsMulTorsionFree M] {n : ℕ} {a b : M}
+
+@[to_additive nsmul_right_injective]
+lemma pow_left_injective (hn : n ≠ 0) : Injective fun a : M ↦ a ^ n :=
+  fun _ _ ↦ (Commute.all _ _).eq_of_pow_eq_pow hn
+
+@[to_additive nsmul_right_inj]
+lemma pow_left_inj (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b := (Commute.all _ _).pow_left_inj hn
+
+@[to_additive (attr := deprecated (since := "2026-09-11")) IsAddTorsionFree.nsmul_right_injective]
+protected alias IsMulTorsionFree.pow_left_injective := pow_left_injective
+
+end CommMonoid
+
+instance [AddCommMonoid M] [IsAddTorsionFree M] : Lean.Grind.NoNatZeroDivisors M where
+  no_nat_zero_divisors _ _ _ hk habk := nsmul_right_injective hk habk
+
 section Group
-variable [Group G] [IsMulTorsionFree G] {n : ℤ} {a b : G}
+variable [Group G] {n : ℤ} {a b : G}
 
-@[to_additive zsmul_right_injective]
-lemma zpow_left_injective : ∀ {n : ℤ}, n ≠ 0 → Injective fun a : G ↦ a ^ n
-  | (n + 1 : ℕ), _ => by
-    simpa [← Int.natCast_one, ← Int.natCast_add] using! pow_left_injective n.succ_ne_zero
-  | .negSucc n, _ => by simpa using! inv_injective.comp (pow_left_injective n.succ_ne_zero)
+/-- A group is torsion-free if and only if it has no non-trivial element of finite order.
 
-@[to_additive zsmul_right_inj]
-lemma zpow_left_inj (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b := (zpow_left_injective hn).eq_iff
+See also `isMulTorsionFree_iff_not_isOfFinOrder`. -/
+@[to_additive
+/-- An additive group is torsion-free if and only if it has no non-zero element of finite order.
 
-/-- Alias of `zpow_left_inj`, for ease of discovery alongside `zsmul_le_zsmul_iff'` and
-`zsmul_lt_zsmul_iff'`. -/
-@[to_additive /-- Alias of `zsmul_right_inj`, for ease of discovery alongside `zsmul_le_zsmul_iff'`
-and `zsmul_lt_zsmul_iff'`. -/]
-lemma zpow_eq_zpow_iff' (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b := zpow_left_inj hn
+See also `isAddTorsionFree_iff_not_isOfFinAddOrder`. -/]
+lemma isMulTorsionFree_iff_eq_one_of_pow_eq_one :
+    IsMulTorsionFree G ↔ ∀ ⦃n : ℕ⦄, n ≠ 0 → ∀ ⦃a : G⦄, a ^ n = 1 → a = 1 where
+  mp _ _ hn _ := (pow_eq_one_iff_left hn).1
+  mpr hG := ⟨fun n hn a b hab habn ↦ by
+    rw [← div_eq_one]
+    refine hG hn ?_
+    rw [div_eq_mul_inv, (Commute.inv_right hab).mul_pow, inv_pow, habn, mul_inv_cancel]⟩
+
+@[to_additive]
+alias ⟨_, IsMulTorsionFree.of_eq_one_of_pow_eq_one⟩ := isMulTorsionFree_iff_eq_one_of_pow_eq_one
+
+variable [IsMulTorsionFree G]
+
+@[to_additive AddCommute.zsmul_right_inj]
+lemma Commute.zpow_left_inj (hab : Commute a b) (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b := by
+  obtain ⟨n, rfl | rfl⟩ := n.eq_nat_or_neg
+  · rw [zpow_natCast, zpow_natCast, hab.pow_left_inj (mod_cast hn)]
+  · rw [zpow_neg, zpow_neg, inv_inj, zpow_natCast, zpow_natCast,
+      hab.pow_left_inj (by simpa using hn)]
 
 @[to_additive IsAddTorsionFree.zsmul_eq_zero_iff_right]
 lemma IsMulTorsionFree.zpow_eq_one_iff_left (hn : n ≠ 0) : a ^ n = 1 ↔ a = 1 := by
-  rw [← zpow_left_inj (a := a) hn, one_zpow]
+  rw [← (Commute.one_right a).zpow_left_inj hn, one_zpow]
 
 -- We want to use `IsAddTorsion.zsmul_eq_zero_iff` earlier than `smul_eq_zero`.
 @[to_additive (attr := simp high)]
@@ -96,3 +145,21 @@ lemma IsMulTorsionFree.zpow_eq_one_iff_right (ha : a ≠ 1) : a ^ n = 1 ↔ n = 
 @[to_additive] lemma isSelfInv_iff_eq_one : IsSelfInv a ↔ a = 1 := inv_eq_self
 
 end Group
+
+section CommGroup
+variable [CommGroup G] [IsMulTorsionFree G] {n : ℤ} {a b : G}
+
+@[to_additive zsmul_right_injective]
+lemma zpow_left_injective (hn : n ≠ 0) : Injective fun a : G ↦ a ^ n :=
+  fun _ _ ↦ ((Commute.all _ _).zpow_left_inj hn).1
+
+@[to_additive zsmul_right_inj]
+lemma zpow_left_inj (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b := (Commute.all _ _).zpow_left_inj hn
+
+/-- Alias of `zpow_left_inj`, for ease of discovery alongside `zsmul_le_zsmul_iff'` and
+`zsmul_lt_zsmul_iff'`. -/
+@[to_additive /-- Alias of `zsmul_right_inj`, for ease of discovery alongside `zsmul_le_zsmul_iff'`
+and `zsmul_lt_zsmul_iff'`. -/]
+lemma zpow_eq_zpow_iff' (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b := zpow_left_inj hn
+
+end CommGroup

--- a/Mathlib/Algebra/Group/TypeTags/Basic.lean
+++ b/Mathlib/Algebra/Group/TypeTags/Basic.lean
@@ -478,10 +478,12 @@ instance Multiplicative.commGroup [AddCommGroup α] : CommGroup (Multiplicative 
   { Multiplicative.group, Multiplicative.commMonoid with }
 
 instance [Monoid α] [IsMulTorsionFree α] : IsAddTorsionFree (Additive α) where
-  nsmul_right_injective _ := pow_left_injective (M := α)
+  eq_of_nsmul_eq_nsmul_of_addCommute _n hn _a _b hab habn :=
+    eq_of_pow_eq_pow_of_commute (M := α) hn hab habn
 
 instance [AddMonoid α] [IsAddTorsionFree α] : IsMulTorsionFree (Multiplicative α) where
-  pow_left_injective _ := nsmul_right_injective (M := α)
+  eq_of_pow_eq_pow_of_commute _n hn _a _b hab habn :=
+    eq_of_nsmul_eq_nsmul_of_addCommute (M := α) hn hab habn
 
 /-- If `α` has some multiplicative structure and coerces to a function,
 then `Additive α` should also coerce to the same function.

--- a/Mathlib/Algebra/GroupWithZero/Torsion.lean
+++ b/Mathlib/Algebra/GroupWithZero/Torsion.lean
@@ -25,7 +25,7 @@ variable {M : Type*} [CommMonoidWithZero M]
 theorem IsMulTorsionFree.mk' [IsReduced M]
     (ih : ∀ x ≠ 0, ∀ y ≠ 0, ∀ n ≠ 0, (x ^ n : M) = y ^ n → x = y) :
     IsMulTorsionFree M := by
-  refine ⟨fun n hn x y hxy ↦ ?_⟩
+  refine .of_pow_left_injective fun n hn x y hxy ↦ ?_
   by_cases h : x ≠ 0 ∧ y ≠ 0
   · exact ih x h.1 y h.2 n hn hxy
   grind [eq_zero_of_pow_eq_zero, zero_pow]

--- a/Mathlib/Algebra/Module/Rat.lean
+++ b/Mathlib/Algebra/Module/Rat.lean
@@ -112,14 +112,14 @@ variable (M) in
 /-- A `ℚ≥0`-module is torsion-free as a group.
 
 This instance will fire for any monoid `M`, so is local unless needed elsewhere. -/
-lemma IsAddTorsionFree.of_module_nnrat [AddCommMonoid M] [Module ℚ≥0 M] : IsAddTorsionFree M where
-  nsmul_right_injective n hn x y hxy := by
+lemma IsAddTorsionFree.of_module_nnrat [AddCommMonoid M] [Module ℚ≥0 M] : IsAddTorsionFree M :=
+  .of_nsmul_right_injective fun n hn x y hxy ↦ by
     simpa [← Nat.cast_smul_eq_nsmul ℚ≥0 n, *] using congr((n⁻¹ : ℚ≥0) • $hxy)
 
 variable (M) in
 /-- A `ℚ≥0`-module is torsion-free as a group.
 
 This instance will fire for any monoid `M`, so is local unless needed elsewhere. -/
-lemma IsAddTorsionFree.of_module_rat [AddCommGroup M] [Module ℚ M] : IsAddTorsionFree M where
-  nsmul_right_injective n hn x y hxy := by
+lemma IsAddTorsionFree.of_module_rat [AddCommGroup M] [Module ℚ M] : IsAddTorsionFree M :=
+  .of_nsmul_right_injective fun n hn x y hxy ↦ by
     simpa [← Nat.cast_smul_eq_nsmul ℚ n, *] using congr((n⁻¹ : ℚ) • $hxy)

--- a/Mathlib/Algebra/Module/Torsion/Free.lean
+++ b/Mathlib/Algebra/Module/Torsion/Free.lean
@@ -122,8 +122,8 @@ variable [CharZero R]
 
 variable (R M) in
 include R in
-lemma IsAddTorsionFree.of_isTorsionFree : IsAddTorsionFree M where
-  nsmul_right_injective n hn := by
+lemma IsAddTorsionFree.of_isTorsionFree : IsAddTorsionFree M :=
+  .of_nsmul_right_injective fun n hn ↦ by
     simp_rw [← Nat.cast_smul_eq_nsmul R]; apply smul_right_injective; simpa
 
 /-- A characteristic zero domain is torsion-free. -/

--- a/Mathlib/Algebra/NoZeroSMulDivisors/Defs.lean
+++ b/Mathlib/Algebra/NoZeroSMulDivisors/Defs.lean
@@ -67,10 +67,8 @@ theorem noZeroSMulDivisors_iff_right_eq_zero_of_smul [Zero R] [Zero M] [SMul R M
 
 instance IsAddTorsionFree.to_noZeroSMulDivisors_nat [AddMonoid M] [IsAddTorsionFree M] :
     NoZeroSMulDivisors ℕ M where
-  eq_zero_or_eq_zero_of_smul_eq_zero {n x} hx := by
-    contrapose! hx; simpa using (nsmul_right_injective hx.1).ne hx.2
+  eq_zero_or_eq_zero_of_smul_eq_zero hx := (nsmul_eq_zero_iff.1 hx).symm
 
 instance IsAddTorsionFree.to_noZeroSMulDivisors_int [AddGroup G] [IsAddTorsionFree G] :
     NoZeroSMulDivisors ℤ G where
-  eq_zero_or_eq_zero_of_smul_eq_zero {n x} hx := by
-    contrapose! hx; simpa using (zsmul_right_injective hx.1).ne hx.2
+  eq_zero_or_eq_zero_of_smul_eq_zero hx := (zsmul_eq_zero_iff.1 hx).symm

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -90,8 +90,8 @@ abbrev Function.Injective.linearOrderedCommMonoidWithZero {β : Type*} [Zero β]
   bot_le _ := le.1 <| bot ▸ bot_le
 
 instance (priority := 100) LinearOrderedCommMonoidWithZero.toIsMulTorsionFree :
-    IsMulTorsionFree α where
-  pow_left_injective n hn := by simpa using (pow_left_strictMonoOn₀ (M₀ := α) hn).injOn
+    IsMulTorsionFree α :=
+  .of_pow_left_injective fun n hn ↦ by simpa using (pow_left_strictMonoOn₀ (M₀ := α) hn).injOn
 
 instance instLinearOrderedAddCommMonoidWithTopAdditiveOrderDual :
     LinearOrderedAddCommMonoidWithTop (Additive αᵒᵈ) where

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Pow.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Pow.lean
@@ -293,8 +293,8 @@ theorem Right.pow_lt_one_iff [MulRightStrictMono M] {n : ℕ} {x : M}
   ⟨fun H => not_le.mp fun k => H.not_ge <| Right.one_le_pow_of_le k, Right.pow_lt_one_of_lt hn⟩
 
 @[to_additive]
-instance [MulLeftStrictMono M] [MulRightStrictMono M] : IsMulTorsionFree M where
-  pow_left_injective _ hn := (pow_left_strictMono hn).injective
+instance [MulLeftStrictMono M] [MulRightStrictMono M] : IsMulTorsionFree M :=
+  .of_pow_left_injective fun _ hn ↦ (pow_left_strictMono hn).injective
 
 end LinearOrder
 

--- a/Mathlib/Algebra/Regular/SMul.lean
+++ b/Mathlib/Algebra/Regular/SMul.lean
@@ -75,12 +75,14 @@ lemma isSMulRegular_map [SMul R M] [SMul S M] (f : R → S) (smul : ∀ m : M, f
 @[to_additive]
 protected alias ⟨IsSMulRegular.of_map, IsSMulRegular.map⟩ := isSMulRegular_map
 
-theorem isAddTorsionFree_iff' [AddMonoid M] : IsAddTorsionFree M ↔ ∀ n ≠ 0, IsSMulRegular M n :=
-  isAddTorsionFree_iff M
+theorem isAddTorsionFree_iff' [AddCommMonoid M] :
+    IsAddTorsionFree M ↔ ∀ n ≠ 0, IsSMulRegular M n where
+  mp _ _ hn _ _ := eq_of_nsmul_eq_nsmul_of_addCommute hn (add_comm _ _)
+  mpr := .of_nsmul_right_injective
 
 namespace IsSMulRegular
 
-theorem nat_of_isAddTorsionFree [AddMonoid M] [IsAddTorsionFree M] {n : ℕ} (h : n ≠ 0) :
+theorem nat_of_isAddTorsionFree [AddCommMonoid M] [IsAddTorsionFree M] {n : ℕ} (h : n ≠ 0) :
     IsSMulRegular M n :=
   isAddTorsionFree_iff'.mp ‹_› n h
 

--- a/Mathlib/Algebra/Ring/CharZero.lean
+++ b/Mathlib/Algebra/Ring/CharZero.lean
@@ -80,8 +80,8 @@ variable [Semiring R] [CharZero R]
 variable [IsCancelMulZero R]
 
 /-- A characteristic zero domain is torsion-free. -/
-instance (priority := 100) IsAddTorsionFree.of_isCancelMulZero_charZero : IsAddTorsionFree R where
-  nsmul_right_injective n hn a b hab := by simpa [hn] using hab
+instance (priority := 100) IsAddTorsionFree.of_isCancelMulZero_charZero : IsAddTorsionFree R :=
+  .of_nsmul_right_injective fun n hn a b hab ↦ by simpa [hn] using hab
 
 end Semiring
 

--- a/Mathlib/Algebra/Ring/Torsion.lean
+++ b/Mathlib/Algebra/Ring/Torsion.lean
@@ -23,10 +23,10 @@ namespace IsDomain
 -- This instance is potentially expensive, and is known to slow down grind.
 -- Please keep it as a scoped instance.
 scoped instance (R : Type*) [Semiring R] [IsDomain R] [CharZero R] :
-    IsAddTorsionFree R where
-  nsmul_right_injective n h a b w := by
-    simp only [nsmul_eq_mul, mul_eq_mul_left_iff, Nat.cast_eq_zero] at w
-    grind
+    IsAddTorsionFree R := by
+  refine .of_nsmul_right_injective fun n h a b w ↦ ?_
+  simp only [nsmul_eq_mul, mul_eq_mul_left_iff, Nat.cast_eq_zero] at w
+  grind
 
 end IsDomain
 

--- a/Mathlib/GroupTheory/FreeGroup/CyclicallyReduced.lean
+++ b/Mathlib/GroupTheory/FreeGroup/CyclicallyReduced.lean
@@ -220,29 +220,29 @@ have the same length, and in fact they have to agree. -/
 @[to_additive /-- Free additive groups are torsion free, i.e., scalar multiplication by every
 non-zero element `n : ℕ` is injective. See the instance for free groups for an overview over the
 proof. -/]
-instance : IsMulTorsionFree (FreeGroup α) where
-  pow_left_injective n hn x y heq := by
-    classical
-    let f (a : FreeGroup α) (n : ℕ) : ℕ :=
-        (conjugator a.toWord).length + (n * (reduceCyclically a.toWord).length +
-          (conjugator a.toWord).length)
-    let g (a : FreeGroup α) (k : ℕ) : List (α × Bool) :=
-        conjugator a.toWord ++ ((replicate k (reduceCyclically a.toWord)).flatten ++
-          invRev (conjugator a.toWord))
-    have heq₂ : x ^ (2 * n) = y ^ (2 * n) := by simp_rw [mul_comm, pow_mul, heq]
-    replace heq : g x n = g y n := by
-      simpa [toWord_pow, reduce_flatten_replicate, isReduced_toWord, hn] using congr_arg toWord heq
-    replace heq₂ : g x (2 * n) = g y (2 * n) := by
-      simpa [toWord_pow, reduce_flatten_replicate, isReduced_toWord, hn] using congr_arg toWord heq₂
-    have leq : f x n = f y n := by simpa [g] using congr_arg List.length heq
-    have leq₂ : f x (2 * n) = f y (2 * n) := by simpa [g] using congr_arg List.length heq₂
-    obtain ⟨hc, heq'⟩ := List.append_inj heq (by grind)
-    obtain ⟨n, rfl⟩ := Nat.exists_eq_add_one_of_ne_zero hn
-    have hm : reduceCyclically x.toWord = reduceCyclically y.toWord := by
-      simp only [replicate_succ, flatten_cons, append_assoc] at heq'
-      exact (List.append_inj heq' <| mul_left_cancel₀ hn <| by grind).1
-    have := congr_arg mk <| (conj_conjugator_reduceCyclically x.toWord).symm
-    rwa [hc, hm, conj_conjugator_reduceCyclically, mk_toWord, mk_toWord] at this
+instance : IsMulTorsionFree (FreeGroup α) := by
+  classical
+  refine .of_pow_left_injective fun n hn x y heq ↦ ?_
+  let f (a : FreeGroup α) (n : ℕ) : ℕ :=
+      (conjugator a.toWord).length + (n * (reduceCyclically a.toWord).length +
+        (conjugator a.toWord).length)
+  let g (a : FreeGroup α) (k : ℕ) : List (α × Bool) :=
+      conjugator a.toWord ++ ((replicate k (reduceCyclically a.toWord)).flatten ++
+        invRev (conjugator a.toWord))
+  have heq₂ : x ^ (2 * n) = y ^ (2 * n) := by simp_rw [mul_comm, pow_mul, heq]
+  replace heq : g x n = g y n := by
+    simpa [toWord_pow, reduce_flatten_replicate, isReduced_toWord, hn] using congr_arg toWord heq
+  replace heq₂ : g x (2 * n) = g y (2 * n) := by
+    simpa [toWord_pow, reduce_flatten_replicate, isReduced_toWord, hn] using congr_arg toWord heq₂
+  have leq : f x n = f y n := by simpa [g] using congr_arg List.length heq
+  have leq₂ : f x (2 * n) = f y (2 * n) := by simpa [g] using congr_arg List.length heq₂
+  obtain ⟨hc, heq'⟩ := List.append_inj heq (by grind)
+  obtain ⟨n, rfl⟩ := Nat.exists_eq_add_one_of_ne_zero hn
+  have hm : reduceCyclically x.toWord = reduceCyclically y.toWord := by
+    simp only [replicate_succ, flatten_cons, append_assoc] at heq'
+    exact (List.append_inj heq' <| mul_left_cancel₀ hn <| by grind).1
+  have := congr_arg mk <| (conj_conjugator_reduceCyclically x.toWord).symm
+  rwa [hc, hm, conj_conjugator_reduceCyclically, mk_toWord, mk_toWord] at this
 
 end IsMulTorsionFree
 end FreeGroup

--- a/Mathlib/GroupTheory/MonoidLocalization/Basic.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization/Basic.lean
@@ -753,17 +753,17 @@ theorem liftOn₂_mk' {p : Sort*} (f : M → S → M → S → p) (H) (a c : M) 
 
 /-- The localization of a torsion-free monoid is torsion-free. -/
 @[to_additive /-- The localization of a torsion-free monoid is torsion-free. -/]
-instance instIsMulTorsionFree [IsMulTorsionFree M] : IsMulTorsionFree <| Localization S where
-  pow_left_injective n hn := by
-    rintro ⟨a⟩ ⟨b⟩ (hab : mk a.1 a.2 ^ n = mk b.1 b.2 ^ n)
-    change mk a.1 a.2 = mk b.1 b.2
-    simp only [mk_pow, mk_eq_mk_iff, r_iff_exists, SubmonoidClass.coe_pow, Subtype.exists,
-      exists_prop] at hab ⊢
-    obtain ⟨c, hc, hab⟩ := hab
-    refine ⟨c, hc, pow_left_injective hn ?_⟩
-    obtain _ | n := n
-    · simp
-    · simp [mul_pow, pow_succ c, mul_assoc, hab]
+instance instIsMulTorsionFree [IsMulTorsionFree M] : IsMulTorsionFree <| Localization S := by
+  refine .of_pow_left_injective fun n hn ↦ ?_
+  rintro ⟨a⟩ ⟨b⟩ (hab : mk a.1 a.2 ^ n = mk b.1 b.2 ^ n)
+  change mk a.1 a.2 = mk b.1 b.2
+  simp only [mk_pow, mk_eq_mk_iff, r_iff_exists, SubmonoidClass.coe_pow, Subtype.exists,
+    exists_prop] at hab ⊢
+  obtain ⟨c, hc, hab⟩ := hab
+  refine ⟨c, hc, pow_left_injective hn ?_⟩
+  obtain _ | n := n
+  · simp
+  · simp [mul_pow, pow_succ c, mul_assoc, hab]
 
 end Localization
 

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -125,7 +125,7 @@ lemma not_isOfFinOrder_of_isMulTorsionFree [IsMulTorsionFree G] (ha : a ≠ 1) :
     ¬ IsOfFinOrder a := by
   rw [isOfFinOrder_iff_pow_eq_one]
   rintro ⟨n, hn, han⟩
-  exact ha <| pow_left_injective hn.ne' <| by simpa using han
+  exact ha <| (pow_eq_one_iff_left hn.ne').1 han
 
 @[to_additive]
 lemma IsOfFinOrder.eq_one' [IsMulTorsionFree G] {a : G} (ha : IsOfFinOrder a) :
@@ -902,6 +902,21 @@ lemma pow_finEquivZPowers_symm_apply (hx : IsOfFinOrder x) (a : Subgroup.zpowers
   simpa only [finEquivZPowers_apply] using
     congr_arg Subtype.val ((finEquivZPowers hx).apply_symm_apply a)
 
+@[to_additive]
+lemma isMulTorsionFree_iff_not_isOfFinOrder :
+    IsMulTorsionFree G ↔ ∀ ⦃a : G⦄, a ≠ 1 → ¬ IsOfFinOrder a where
+  mp _ _ := not_isOfFinOrder_of_isMulTorsionFree
+  mpr hG := .of_eq_one_of_pow_eq_one fun n hn a han ↦
+    of_not_not fun ha ↦ hG ha <| isOfFinOrder_iff_pow_eq_one.2 ⟨n, n.pos_of_ne_zero hn, han⟩
+
+@[to_additive]
+alias ⟨_, IsMulTorsionFree.of_not_isOfFinOrder⟩ := isMulTorsionFree_iff_not_isOfFinOrder
+
+@[to_additive]
+lemma not_isMulTorsionFree_iff_isOfFinOrder :
+    ¬ IsMulTorsionFree G ↔ ∃ a ≠ (1 : G), IsOfFinOrder a := by
+  simp [isMulTorsionFree_iff_not_isOfFinOrder]
+
 end Group
 
 section CommMonoid
@@ -917,24 +932,6 @@ end CommMonoid
 
 section CommGroup
 variable [CommGroup G]
-
-@[to_additive]
-lemma isMulTorsionFree_iff_not_isOfFinOrder :
-    IsMulTorsionFree G ↔ ∀ ⦃a : G⦄, a ≠ 1 → ¬ IsOfFinOrder a where
-  mp _ _ := not_isOfFinOrder_of_isMulTorsionFree
-  mpr hG := by
-    refine ⟨fun n hn a b hab ↦ ?_⟩
-    rw [← div_eq_one] at hab ⊢
-    simp only [← div_pow, isOfFinOrder_iff_pow_eq_one] at hab hG
-    exact of_not_not fun hab' ↦ hG hab' ⟨n, hn.bot_lt, hab⟩
-
-@[to_additive]
-alias ⟨_, IsMulTorsionFree.of_not_isOfFinOrder⟩ := isMulTorsionFree_iff_not_isOfFinOrder
-
-@[to_additive]
-lemma not_isMulTorsionFree_iff_isOfFinOrder :
-    ¬ IsMulTorsionFree G ↔ ∃ a ≠ (1 : G), IsOfFinOrder a := by
-  simp [isMulTorsionFree_iff_not_isOfFinOrder]
 
 @[to_additive (attr := simp)]
 lemma zpowers_mabs [LinearOrder G] [IsOrderedMonoid G] (g : G) : zpowers |g|ₘ = zpowers g := by

--- a/Mathlib/NumberTheory/Padics/MahlerBasis.lean
+++ b/Mathlib/NumberTheory/Padics/MahlerBasis.lean
@@ -70,8 +70,7 @@ lemma norm_ascPochhammer_le (k : ℕ) (x : ℤ_[p]) :
     ← Ring.factorial_nsmul_multichoose_eq_ascPochhammer, smul_eq_mul, Nat.cast_mul, norm_mul]
   exact mul_le_of_le_one_right (norm_nonneg _) (norm_le_one _)
 
-instance : IsAddTorsionFree ℤ_[p] where
-  nsmul_right_injective _ := smul_right_injective ℤ_[p]
+instance : IsAddTorsionFree ℤ_[p] := .of_nsmul_right_injective fun _ ↦ smul_right_injective ℤ_[p]
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The p-adic integers are a binomial ring, i.e. a ring where binomial coefficients make sense. -/


### PR DESCRIPTION
In #24311 I replaced `Monoid.IsTorsionFree M`, which says that the identity is the only element of `M` of finite order, in favor of `IsMulTorsionFree M`, which says `a ↦ a ^ n` to be injective for all `n ≠ 0`.

The two definitions are equivalent for commutative groups, but disagree over both groups and commutative monoids:
* If `M` is a group, then `Monoid.IsTorsionFree M` is the right definition. For example, the Promislow group is described as torsion-free in the literature but, using the standard presentation, `a²b ≠ b` while `(a²b)² = b²`, so it doesn't satisfy `IsMulTorsionFree`.
* If `M` is a commutative monoid, then `IsMulTorsionFree M` is the right definition. `Monoid.IsTorsionFree M` does not imply `Monoid.IsTorsionFree (GrothendieckGroup M)`, but `IsMulTorsionFree M` implies `IsMulTorsionFree (GrothendieckGroup M)`.

My suggested fix is to change `IsMulTorsionFree` to require `a ^ n = b ^ n` to imply `a = b` for all `n ≠ 0` only if `a` and `b` commute. This gives the correct definition in both groups and commutative monoids. I couldn't find much literature on torsion-free non-commutative monoids, and therefore cannot vouch for this definition being correct in that setting.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
