### PR TITLE
[Merged by Bors] - feat(NumberTheory/ModularForms): restrict a mod form to a subgroup

### DIFF
--- a/Mathlib/NumberTheory/ModularForms/Basic.lean
+++ b/Mathlib/NumberTheory/ModularForms/Basic.lean
@@ -23,13 +23,11 @@ define the space of modular forms, cusp forms and prove that the product of two 
 modular form.
 -/
 
-@[expose] public section
+@[expose] public noncomputable section
 
 open Complex UpperHalfPlane Matrix.SpecialLinearGroup
 
 open scoped Topology Manifold MatrixGroups ComplexConjugate
-
-noncomputable section
 
 section ModularForm
 
@@ -648,48 +646,6 @@ end GradedRing
 
 end ModularForm
 
-section translate
-
-open ModularForm OnePoint
-
-variable {k : ℤ} {Γ : Subgroup (GL (Fin 2) ℝ)} {F : Type*} [FunLike F ℍ ℂ] (f : F)
-
-open ConjAct Pointwise in
-/-- Translating a `ModularForm` by `GL(2, ℝ)`, to obtain a new `ModularForm`. -/
-noncomputable def ModularForm.translate [ModularFormClass F Γ k] (g : GL (Fin 2) ℝ) :
-    ModularForm (toConjAct g⁻¹ • Γ) k where
-  __ := SlashInvariantForm.translate f g
-  bdd_at_cusps' {c} hc γ hγ := by
-    rw [SlashInvariantForm.toFun_eq_coe, SlashInvariantForm.coe_translate,
-      ← SlashAction.slash_mul, ← isBoundedAt_infty_iff, ← OnePoint.IsBoundedAt.smul_iff]
-    apply ModularFormClass.bdd_at_cusps f
-    simpa [mul_smul, hγ] using hc.smul g
-  holo' := (ModularFormClass.holo f).slash k g
-
-@[simp]
-lemma ModularForm.coe_translate [ModularFormClass F Γ k] (g : GL (Fin 2) ℝ) :
-    translate f g = ⇑f ∣[k] g :=
-  rfl
-
-open ConjAct Pointwise in
-/-- Translating a `CuspForm` by `SL(2, ℤ)`, to obtain a new `CuspForm`. -/
-noncomputable def CuspForm.translate [CuspFormClass F Γ k] (g : GL (Fin 2) ℝ) :
-    CuspForm (toConjAct g⁻¹ • Γ) k where
-  __ := ModularForm.translate f g
-  zero_at_cusps' {c} hc γ hγ := by
-    rw [SlashInvariantForm.toFun_eq_coe, ModularForm.toSlashInvariantForm_coe,
-      ModularForm.coe_translate, ← SlashAction.slash_mul, ← isZeroAt_infty_iff,
-      ← OnePoint.IsZeroAt.smul_iff]
-    apply CuspFormClass.zero_at_cusps f
-    simpa [mul_smul, hγ] using hc.smul g
-
-@[simp]
-lemma CuspForm.coe_translate [CuspFormClass F Γ k] (g : SL(2, ℤ)) :
-    translate f g = ⇑f ∣[k] g :=
-  rfl
-
-end translate
-
 section SL2Z
 
 open ModularForm OnePoint
@@ -725,3 +681,5 @@ lemma CuspFormClass.zero_at_infty_slash [CuspFormClass F Γ k] :
   exact ⟨g, by simp [mapGL]⟩
 
 end SL2Z
+
+end

--- a/Mathlib/NumberTheory/ModularForms/Bounds.lean
+++ b/Mathlib/NumberTheory/ModularForms/Bounds.lean
@@ -6,7 +6,7 @@ Authors: David Loeffler
 module
 
 public import Mathlib.Analysis.Fourier.AddCircle
-public import Mathlib.NumberTheory.Modular
+public import Mathlib.NumberTheory.ModularForms.NormTrace
 public import Mathlib.NumberTheory.ModularForms.Petersson
 
 /-!

--- a/Mathlib/NumberTheory/ModularForms/NormTrace.lean
+++ b/Mathlib/NumberTheory/ModularForms/NormTrace.lean
@@ -8,19 +8,162 @@ module
 public import Mathlib.NumberTheory.ModularForms.LevelOne.Basic
 
 /-!
-# Norm and trace maps
+# Restriction, translation, norm and trace
 
-Given two subgroups `𝒢, ℋ` of `GL(2, ℝ)` with `𝒢.relindex ℋ ≠ 0` (i.e. `𝒢 ⊓ ℋ` has finite index
-in `ℋ`), we define a trace map from `ModularForm (𝒢 ⊓ ℋ) k` to `ModularForm ℋ k`.
+This file defines operations on modular forms, cusp forms, and slash-invariant forms which change
+the level:
+
+* restriction maps (making the level group smaller, without changing the underlying function)
+* translation maps (acting by a slash operator on the underlying function, and conjugating the
+  level group)
+* trace and norm maps (making the level group larger, by taking a sum / product of translates by
+  coset representatives).
+
+As an application, we show that a modular form of weight `≤ 0` (and any level) must be
+constant, using norm maps to reduce to the case of level `SL(2, ℤ)`.
 -/
 
 @[expose] public noncomputable section
 
-open UpperHalfPlane
+open UpperHalfPlane ModularForm OnePoint
 
 open scoped ModularForm Topology Filter Manifold
 
-variable {𝒢 ℋ : Subgroup (GL (Fin 2) ℝ)} {F : Type*} (f : F) [FunLike F ℍ ℂ] {k : ℤ}
+variable {𝒢 ℋ : Subgroup (GL (Fin 2) ℝ)} {F : Type*} [FunLike F ℍ ℂ]
+  {k : ℤ} {f : F} {g : GL (Fin 2) ℝ}
+
+section Translate
+
+open ConjAct Pointwise
+
+variable (f g) in
+/-- Translating a `SlashInvariantForm` by `g : GL (Fin 2) ℝ`, to obtain a new
+`SlashInvariantForm` of level `g⁻¹ 𝒢 g`. -/
+noncomputable def SlashInvariantForm.translate [SlashInvariantFormClass F 𝒢 k] :
+    SlashInvariantForm (toConjAct g⁻¹ • 𝒢) k where
+  toFun := f ∣[k] g
+  slash_action_eq' j hj := by
+    rw [map_inv, 𝒢.mem_inv_pointwise_smul_iff, toConjAct_smul] at hj
+    simpa [← SlashAction.slash_mul] using congr_arg (· ∣[k] g) (slash_action_eqn f _ hj)
+
+@[simp]
+lemma SlashInvariantForm.coe_translate [SlashInvariantFormClass F 𝒢 k] :
+    SlashInvariantForm.translate f g = ⇑f ∣[k] g :=
+  (rfl)
+
+variable (f g) in
+/-- Translating a `ModularForm` by `GL(2, ℝ)`, to obtain a new `ModularForm`. -/
+noncomputable def ModularForm.translate [ModularFormClass F 𝒢 k] :
+    ModularForm (toConjAct g⁻¹ • 𝒢) k where
+  __ := SlashInvariantForm.translate f g
+  bdd_at_cusps' {c} hc γ hγ := by
+    rw [SlashInvariantForm.toFun_eq_coe, SlashInvariantForm.coe_translate,
+      ← SlashAction.slash_mul, ← isBoundedAt_infty_iff, ← OnePoint.IsBoundedAt.smul_iff]
+    apply ModularFormClass.bdd_at_cusps f
+    simpa [mul_smul, hγ] using hc.smul g
+  holo' := (ModularFormClass.holo f).slash k g
+
+@[simp] lemma ModularForm.coe_translate [ModularFormClass F 𝒢 k] :
+    translate f g = ⇑f ∣[k] g :=
+  (rfl)
+
+variable (f g) in
+/-- Translating a `CuspForm` by `SL(2, ℤ)`, to obtain a new `CuspForm`. -/
+noncomputable def CuspForm.translate [CuspFormClass F 𝒢 k] :
+    CuspForm (toConjAct g⁻¹ • 𝒢) k where
+  __ := ModularForm.translate f g
+  zero_at_cusps' {c} hc γ hγ := by
+    rw [SlashInvariantForm.toFun_eq_coe, ModularForm.toSlashInvariantForm_coe,
+      ModularForm.coe_translate, ← SlashAction.slash_mul, ← isZeroAt_infty_iff,
+      ← OnePoint.IsZeroAt.smul_iff]
+    apply CuspFormClass.zero_at_cusps f
+    simpa [mul_smul, hγ] using hc.smul g
+
+@[simp] lemma CuspForm.coe_translate [CuspFormClass F 𝒢 k] :
+    translate f g = ⇑f ∣[k] g :=
+  (rfl)
+
+end Translate
+
+section Restrict
+
+namespace SlashInvariantForm
+
+/-- Regard a modular form as a form for a subgroup of its level. -/
+def restrict (hGH : 𝒢 ≤ ℋ) (f : SlashInvariantForm ℋ k) : SlashInvariantForm 𝒢 k where
+  toFun := f
+  slash_action_eq' g hg := f.slash_action_eq' g (hGH hg)
+
+@[simp] lemma coe_restrict (hGH : 𝒢 ≤ ℋ) {f : SlashInvariantForm ℋ k} :
+    ⇑(restrict hGH f) = f :=
+  (rfl)
+
+lemma restrict_injective (hGH : 𝒢 ≤ ℋ) : Function.Injective (restrict (k := k) hGH) :=
+  fun _ _ hfg ↦ ext fun τ ↦ congr($hfg τ)
+
+@[simp] lemma restrict_eq_zero_iff (hGH : 𝒢 ≤ ℋ) {f : SlashInvariantForm ℋ k} :
+    restrict hGH f = 0 ↔ f = 0 := by
+  rw [← (restrict_injective hGH).eq_iff, show restrict hGH 0 = 0 by rfl]
+
+@[simp] lemma restrict_translate (hGH : 𝒢 ≤ ℋ) {f : SlashInvariantForm ℋ k} (g) :
+    restrict (by simpa using hGH) (translate f g) = translate (restrict hGH f) g :=
+  (rfl)
+
+end SlashInvariantForm
+
+namespace ModularForm
+
+/-- Regard a modular form as a form for a subgroup of its level. -/
+def restrict (hGH : 𝒢 ≤ ℋ) (f : ModularForm ℋ k) : ModularForm 𝒢 k where
+  toFun := f
+  slash_action_eq' g hg := f.slash_action_eq' g (hGH hg)
+  holo' := f.holo'
+  bdd_at_cusps' hc := f.bdd_at_cusps' (hc.mono hGH)
+
+@[simp] lemma coe_restrict (hGH : 𝒢 ≤ ℋ) {f : ModularForm ℋ k} :
+    ⇑(restrict hGH f) = f :=
+  rfl
+
+lemma restrict_injective (hGH : 𝒢 ≤ ℋ) : Function.Injective (restrict (k := k) hGH) :=
+  fun _ _ hfg ↦ ext fun τ ↦ congr($hfg τ)
+
+@[simp] lemma restrict_eq_zero_iff (hGH : 𝒢 ≤ ℋ) {f : ModularForm ℋ k} :
+    restrict hGH f = 0 ↔ f = 0 := by
+  rw [← (restrict_injective hGH).eq_iff, show restrict hGH 0 = 0 by rfl]
+
+@[simp] lemma restrict_translate (hGH : 𝒢 ≤ ℋ) {f : ModularForm ℋ k} (g) :
+    restrict (by simpa using hGH) (translate f g) = translate (restrict hGH f) g :=
+  rfl
+
+end ModularForm
+
+namespace CuspForm
+
+/-- Regard a modular form as a form for a subgroup of its level. -/
+def restrict (hGH : 𝒢 ≤ ℋ) (f : CuspForm ℋ k) : CuspForm 𝒢 k where
+  toFun := f
+  slash_action_eq' g hg := f.slash_action_eq' g (hGH hg)
+  holo' := f.holo'
+  zero_at_cusps' hc := f.zero_at_cusps' (hc.mono hGH)
+
+@[simp] lemma coe_restrict (hGH : 𝒢 ≤ ℋ) {f : CuspForm ℋ k} :
+    ⇑(restrict hGH f) = f :=
+  rfl
+
+lemma restrict_injective (hGH : 𝒢 ≤ ℋ) : Function.Injective (restrict (k := k) hGH) :=
+  fun _ _ hfg ↦ ext fun τ ↦ congr($hfg τ)
+
+@[simp] lemma restrict_eq_zero_iff (hGH : 𝒢 ≤ ℋ) {f : CuspForm ℋ k} :
+    restrict hGH f = 0 ↔ f = 0 := by
+  rw [← (restrict_injective hGH).eq_iff, show restrict hGH 0 = 0 by rfl]
+
+@[simp] lemma restrict_translate (hGH : 𝒢 ≤ ℋ) {f : CuspForm ℋ k} (g) :
+    restrict (by simpa using hGH) (translate f g) = translate (restrict hGH f) g :=
+  rfl
+
+end CuspForm
+
+end Restrict
 
 local notation "𝒬" => ℋ ⧸ (𝒢.subgroupOf ℋ)
 
@@ -29,7 +172,7 @@ instance : MulAction ℋ 𝒬 := .quotient ..
 
 namespace SlashInvariantForm
 
-variable [SlashInvariantFormClass F 𝒢 k]
+variable [SlashInvariantFormClass F 𝒢 k] (f : F)
 
 /-- For `f` invariant under `𝒢`, this is a function on `(ℋ ⧸ 𝒢 ⊓ ℋ) × ℍ → ℂ` which packages up the
 translates of `f` by `ℋ`. -/
@@ -75,7 +218,7 @@ open SlashInvariantForm
 
 section ModularForm
 
-variable (ℋ) [𝒢.IsFiniteRelIndex ℋ]
+variable (ℋ) (f) [𝒢.IsFiniteRelIndex ℋ]
 
 /-- The trace of a modular form, as a modular form. -/
 @[simps! -fullyApplied]

--- a/Mathlib/NumberTheory/ModularForms/SlashInvariantForms.lean
+++ b/Mathlib/NumberTheory/ModularForms/SlashInvariantForms.lean
@@ -277,19 +277,4 @@ instance [Γ.HasDetPlusMinusOne] : IntCast (SlashInvariantForm Γ 0) where
 @[simp, norm_cast]
 theorem coe_intCast [Γ.HasDetPlusMinusOne] (z : ℤ) : ⇑(z : SlashInvariantForm Γ 0) = z := rfl
 
-open ConjAct Pointwise in
-/-- Translating a `SlashInvariantForm` by `g : GL (Fin 2) ℝ`, to obtain a new
-`SlashInvariantForm` of level `g⁻¹ Γ g`. -/
-noncomputable def translate [SlashInvariantFormClass F Γ k] (f : F) (g : GL (Fin 2) ℝ) :
-    SlashInvariantForm (toConjAct g⁻¹ • Γ) k where
-  toFun := f ∣[k] g
-  slash_action_eq' j hj := by
-    rw [map_inv, Γ.mem_inv_pointwise_smul_iff, toConjAct_smul] at hj
-    simpa [← SlashAction.slash_mul] using congr_arg (· ∣[k] g) (slash_action_eqn f _ hj)
-
-@[simp]
-lemma coe_translate [SlashInvariantFormClass F Γ k] (f : F) (g : GL (Fin 2) ℝ) :
-    translate f g = ⇑f ∣[k] g :=
-  rfl
-
 end SlashInvariantForm


### PR DESCRIPTION
For `𝒢 ≤ ℋ` subgroups of `GL(2, ℝ)`, define the natural map from modular forms of level `ℋ` to modular forms of level `𝒢` (the identity on underlying functions). Also refactor some related existing code (translation and norm/trace maps) to gather it together in one file.

---
AI use: Based on code originally written by ChatGPT 5.6 Sol and 6.0 Astra, but carefully checked and cleaned up by me.

Spun off from #43644