### PR TITLE
[Merged by Bors] - feat: add `Filter.HasBasis.iInf_of_finite`

### DIFF
--- a/Mathlib/Order/Filter/Bases/Finite.lean
+++ b/Mathlib/Order/Filter/Bases/Finite.lean
@@ -85,6 +85,26 @@ protected theorem HasBasis.iInf {ι : Type*} {ι' : ι → Type*} {l : ι → Fi
     cases hI.nonempty_fintype
     exact iInter_mem.2 fun i => mem_iInf_of_mem ↑i <| (hl i).mem_of_mem <| hf _
 
+/-- When the indexing type is finite, `⨅ i, l i` has a basis consisting of intersections of sets
+from bases of each `l i`. -/
+theorem HasBasis.iInf_of_finite {ι : Type*} {ι' : ι → Type*} [Finite ι]
+    {l : ι → Filter α} {p : ∀ i, ι' i → Prop} {s : ∀ i, ι' i → Set α}
+    (hl : ∀ i, (l i).HasBasis (p i) (s i)) :
+    (⨅ i, l i).HasBasis (fun f : ∀ i, ι' i ↦ ∀ i, p i (f i)) fun f ↦ ⋂ i, s i (f i) := by
+  refine ⟨fun t ↦ ⟨fun ht ↦ ?_, fun ⟨f, hf, hsub⟩ ↦ ?_⟩⟩
+  · obtain ⟨u, hu, rfl⟩ := (mem_iInf_of_finite t).1 ht
+    choose f hf hsub using fun i ↦ (hl i).mem_iff.1 (hu i)
+    exact ⟨f, hf, iInter_mono hsub⟩
+  · exact mem_of_superset (iInter_mem.2 fun i ↦ mem_iInf_of_mem i <| (hl i).mem_of_mem (hf i)) hsub
+
+theorem HasBasis.biInf_of_finset {ι : Type*} {ι' : ι → Type*} (I : Finset ι)
+    {l : ι → Filter α} {p : ∀ i, ι' i → Prop} {s : ∀ i, ι' i → Set α}
+    (hl : ∀ i ∈ I, (l i).HasBasis (p i) (s i)) :
+    (⨅ i ∈ I, l i).HasBasis (fun f : ∀ i : I, ι' i ↦ ∀ i : I, p i (f i))
+      fun f ↦ ⋂ i : I, s i (f i) := by
+  rw [iInf_subtype']
+  exact HasBasis.iInf_of_finite fun i : I ↦ hl i i.2
+
 open scoped Function in -- required for scoped `on` notation
 theorem _root_.Pairwise.exists_mem_filter_basis_of_disjoint {I} [Finite I] {l : I → Filter α}
     {ι : I → Sort*} {p : ∀ i, ι i → Prop} {s : ∀ i, ι i → Set α} (hd : Pairwise (Disjoint on l))


### PR DESCRIPTION
---

I find it very hard to believe we don't have this already, but [loogle](https://loogle.lean-lang.org/?q=%7C-+Filter.HasBasis+%28iInf+_%29+_+_) tells me we don't.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
